### PR TITLE
Restart BEL upgrade for Java 17, Payara 7, Jakarta EE 11 and java.time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,19 +14,19 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
         <skipTests>true</skipTests>
 
-        <!-- Java EE 8 / Payara 5 line. Do not change these to jakarta.* until the Payara 7 migration. -->
-        <javaee.version>8.0.1</javaee.version>
-        <eclipselink.version>2.7.12</eclipselink.version>
+        <!-- Java 17 / Jakarta EE 11 migration line. Payara provides the Jakarta APIs at runtime. -->
+        <jakartaee.version>11.0.0</jakartaee.version>
+        <eclipselink.version>5.0.0-B10</eclipselink.version>
         <mysql.connector.version>8.2.0</mysql.connector.version>
-        <jackson.version>2.13.3</jackson.version>
-        <zxing.version>3.3.2</zxing.version>
-        <batik.version>1.10</batik.version>
+        <jackson.version>2.17.2</jackson.version>
+        <zxing.version>3.5.3</zxing.version>
+        <batik.version>1.17</batik.version>
         <jfreechart.version>1.5.5</jfreechart.version>
-        <javax.mail.version>1.6.2</javax.mail.version>
+        <jakarta.mail.version>2.1.3</jakarta.mail.version>
+        <angus.mail.version>2.0.3</angus.mail.version>
         <junit.version>4.13.2</junit.version>
     </properties>
 
@@ -35,10 +35,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.11.0</version>
+                <version>3.13.0</version>
                 <configuration>
-                    <source>${maven.compiler.source}</source>
-                    <target>${maven.compiler.target}</target>
+                    <release>${maven.compiler.release}</release>
                     <parameters>true</parameters>
                 </configuration>
             </plugin>
@@ -46,7 +45,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.2.5</version>
                 <configuration>
                     <skipTests>${skipTests}</skipTests>
                 </configuration>
@@ -55,15 +54,13 @@
     </build>
 
     <dependencies>
-        <!-- Payara 5 provides the Java EE 8 APIs at runtime. Keep this as provided. -->
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>${javaee.version}</version>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>${jakartaee.version}</version>
             <scope>provided</scope>
         </dependency>
 
-        <!-- Payara 5 includes EclipseLink 2.7.x. Keep provider-specific compile APIs out of the packaged JAR/WAR. -->
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>org.eclipse.persistence.jpa</artifactId>
@@ -71,7 +68,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Keep only if BEL uses MOXy-specific annotations/classes. Otherwise this can be removed. -->
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>org.eclipse.persistence.moxy</artifactId>
@@ -87,13 +83,17 @@
             <scope>runtime</scope>
         </dependency>
 
-
-        <!-- Java EE 8 / javax.mail. Keep this until the Jakarta EE migration.
-             Needed because BEL directly imports javax.mail.* classes. -->
         <dependency>
-            <groupId>com.sun.mail</groupId>
-            <artifactId>javax.mail</artifactId>
-            <version>${javax.mail.version}</version>
+            <groupId>jakarta.mail</groupId>
+            <artifactId>jakarta.mail-api</artifactId>
+            <version>${jakarta.mail.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.angus</groupId>
+            <artifactId>angus-mail</artifactId>
+            <version>${angus.mail.version}</version>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>
@@ -125,12 +125,6 @@
             <groupId>org.jfree</groupId>
             <artifactId>jfreechart</artifactId>
             <version>${jfreechart.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jfree</groupId>
-            <artifactId>jcommon</artifactId>
-            <version>1.0.24</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>jm.com.dpbennett</groupId>
     <artifactId>business-entity-library</artifactId>
-    <version>2.0.0</version>
+    <version>6.0.0</version>
     <packaging>jar</packaging>
 
     <name>a.BEL</name>

--- a/src/main/java/jm/com/dpbennett/business/entity/BusinessEntity.java
+++ b/src/main/java/jm/com/dpbennett/business/entity/BusinessEntity.java
@@ -1,5 +1,5 @@
 /*
-Business Entity Library (BEL) - A foundational library. 
+Business Entity Library (BEL) - A foundational library.
 Copyright (C) 2026  D P Bennett & Associates Limited
 
 This program is free software: you can redistribute it and/or modify
@@ -17,101 +17,96 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Email: info@dpbennett.com.jm
  */
-
 package jm.com.dpbennett.business.entity;
 
+import jakarta.persistence.EntityManager;
 import java.io.Serializable;
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
-import javax.persistence.EntityManager;
 import jm.com.dpbennett.business.entity.sm.SystemOption;
 import jm.com.dpbennett.business.entity.util.ReturnMessage;
 
 /**
+ * Common contract implemented by BEL business entities.
+ *
+ * Audit values include both a date and a time, so LocalDateTime is used for
+ * dateEntered and dateEdited. Domain values representing calendar-only dates
+ * should use LocalDate instead.
  *
  * @author Desmond Bennett
  */
 public interface BusinessEntity extends Serializable {
 
-    public Long getId();
+    Long getId();
 
-    public void setId(Long id);
+    void setId(Long id);
 
-    public Boolean getActive();
+    Boolean getActive();
 
-    public void setActive(Boolean active);
+    void setActive(Boolean active);
 
-    public String getName();
+    String getName();
 
-    public void setName(String name);
+    void setName(String name);
 
-    public String getType();
+    String getType();
 
-    public void setType(String type);
+    void setType(String type);
 
-    public String getCategory();
+    String getCategory();
 
-    public void setCategory(String category);
+    void setCategory(String category);
 
-    public Date getDateEntered();
+    LocalDateTime getDateEntered();
 
-    public void setDateEntered(Date dateEntered);
+    void setDateEntered(LocalDateTime dateEntered);
 
-    public Date getDateEdited();
+    LocalDateTime getDateEdited();
 
-    public void setDateEdited(Date dateEdited);
+    void setDateEdited(LocalDateTime dateEdited);
 
-    public ReturnMessage save(EntityManager em);
+    ReturnMessage save(EntityManager em);
 
-    public ReturnMessage saveUnique(EntityManager em);
+    ReturnMessage saveUnique(EntityManager em);
 
-    public ReturnMessage delete(EntityManager em);
+    ReturnMessage delete(EntityManager em);
 
-    public ReturnMessage validate(EntityManager em);
+    ReturnMessage validate(EntityManager em);
 
-    public Boolean getIsDirty();
+    Boolean getIsDirty();
 
-    public void setIsDirty(Boolean isDirty);
+    void setIsDirty(Boolean isDirty);
 
-    public String getDescription();
+    String getDescription();
 
-    public void setDescription(String description);
+    void setDescription(String description);
 
-    public String getNotes();
+    String getNotes();
 
-    public void setNotes(String notes);
+    void setNotes(String notes);
 
-    public String getComments();
+    String getComments();
 
-    public void setComments(String comments);
+    void setComments(String comments);
 
-    public Person getEditedBy();
+    Person getEditedBy();
 
-    public void setEditedBy(Person person);
+    void setEditedBy(Person person);
 
-    public Person getEnteredBy();
+    Person getEnteredBy();
 
-    public void setEnteredBy(Person person);
+    void setEnteredBy(Person person);
 
-    public List<SystemOption> getSettings();
+    List<SystemOption> getSettings();
 
-    public void setSettings(List<SystemOption> settings);
+    void setSettings(List<SystemOption> settings);
 
-    public SystemOption getSetting(
-            String setting,
-            String settingValue,
-            String type,
-            String category);
+    SystemOption getSetting(String setting, String settingValue, String type, String category);
 
-    public void setSetting(
-            String setting,
-            String settingValue,
-            String type,
-            String category);
+    void setSetting(String setting, String settingValue, String type, String category);
 
-    public enum Action {
+    enum Action {
         CREATE, COMPLETE, EDIT, APPROVE, DELETE, CANCEL, PREPARE, INVOICE,
         COSTING, REQUEST, PAYMENT, RECOMMEND
     }
-
 }

--- a/src/main/java/jm/com/dpbennett/business/entity/DefaultEntity.java
+++ b/src/main/java/jm/com/dpbennett/business/entity/DefaultEntity.java
@@ -19,9 +19,10 @@ Email: info@dpbennett.com.jm
  */
 package jm.com.dpbennett.business.entity;
 
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.List;
-import javax.persistence.EntityManager;
 import jm.com.dpbennett.business.entity.sm.SystemOption;
 import jm.com.dpbennett.business.entity.util.ReturnMessage;
 
@@ -30,6 +31,9 @@ import jm.com.dpbennett.business.entity.util.ReturnMessage;
  * @author Desmond Bennett
  */
 public class DefaultEntity implements BusinessEntity {
+
+    private static final long serialVersionUID = 1L;
+    private static final System.Logger LOG = System.getLogger(DefaultEntity.class.getName());
 
     @Override
     public Long getId() {
@@ -78,26 +82,6 @@ public class DefaultEntity implements BusinessEntity {
 
     @Override
     public void setCategory(String category) {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
-    }
-
-    @Override
-    public Date getDateEntered() {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
-    }
-
-    @Override
-    public void setDateEntered(Date dateEntered) {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
-    }
-
-    @Override
-    public Date getDateEdited() {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
-    }
-
-    @Override
-    public void setDateEdited(Date dateEdited) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
@@ -240,6 +224,26 @@ public class DefaultEntity implements BusinessEntity {
 
         getSettings().add(so);
 
+    }
+
+    @Override
+    public void setDateEntered(LocalDateTime dateEntered) {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public void setDateEdited(LocalDateTime dateEdited) {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public LocalDateTime getDateEntered() {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public LocalDateTime getDateEdited() {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
 }

--- a/src/main/java/jm/com/dpbennett/business/entity/Field.java
+++ b/src/main/java/jm/com/dpbennett/business/entity/Field.java
@@ -17,23 +17,22 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Email: info@dpbennett.com.jm
  */
-
 package jm.com.dpbennett.business.entity;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import java.io.Serializable;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EntityManager;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.NamedQueries;
-import javax.persistence.NamedQuery;
-import javax.persistence.Table;
-import javax.persistence.Transient;
 import jm.com.dpbennett.business.entity.sm.SystemOption;
 import jm.com.dpbennett.business.entity.util.BusinessEntityUtils;
 import jm.com.dpbennett.business.entity.util.ReturnMessage;
@@ -51,6 +50,123 @@ import jm.com.dpbennett.business.entity.util.ReturnMessage;
 public class Field implements Serializable, BusinessEntity {
 
     private static final long serialVersionUID = 1L;
+    private static final System.Logger LOG = System.getLogger(Field.class.getName());
+
+    public static List<Field> findAllFields(EntityManager em) {
+
+        try {
+            List<Field> codes = em.createNamedQuery("findAllFields", Field.class).getResultList();
+
+            return codes;
+
+        } catch (Exception e) {
+            System.out.println(e);
+            return null;
+        }
+    }
+
+    public static List<Field> findFields(EntityManager em, String value) {
+
+        try {
+
+            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
+
+            List<Field> fields
+                    = em.createQuery("SELECT a FROM Field a WHERE UPPER(a.name) LIKE '%" + value.toUpperCase().trim()
+                            + "%' OR UPPER(a.description) LIKE '%" + value.toUpperCase().trim()
+                            + "%' OR UPPER(a.code) LIKE '%" + value.toUpperCase().trim()
+                            + "%' OR UPPER(a.account) LIKE '%" + value.toUpperCase().trim()
+                            + "%' OR UPPER(a.type) LIKE '%" + value.toUpperCase().trim()
+                            + "%' OR UPPER(a.abbreviation) LIKE '%" + value.toUpperCase().trim()
+                            + "%' ORDER BY a.name",
+                            Field.class).getResultList();
+
+            return fields;
+
+        } catch (Exception e) {
+            System.out.println(e);
+            return new ArrayList<>();
+        }
+    }
+
+    public static List<Field> findActiveFields(EntityManager em, String value) {
+
+        try {
+
+            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
+
+            List<Field> fields
+                    = em.createQuery("SELECT a FROM Field a WHERE (UPPER(a.name) LIKE '%" + value.toUpperCase().trim()
+                            + "%' OR UPPER(a.description) LIKE '%" + value.toUpperCase().trim()
+                            + "%' OR UPPER(a.code) LIKE '%" + value.toUpperCase().trim()
+                            + "%' OR UPPER(a.account) LIKE '%" + value.toUpperCase().trim()
+                            + "%' OR UPPER(a.type) LIKE '%" + value.toUpperCase().trim()
+                            + "%' OR UPPER(a.abbreviation) LIKE '%" + value.toUpperCase().trim()
+                            + "%') AND (a.active = 1 OR a.active IS NULL) ORDER BY a.name",
+                            Field.class).getResultList();
+            return fields;
+        } catch (Exception e) {
+            System.out.println(e);
+            return new ArrayList<>();
+        }
+    }
+
+    public static Field findByName(EntityManager em, String value) {
+
+        try {
+
+            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
+
+            List<Field> fields = em.createQuery("SELECT a FROM Field a "
+                    + "WHERE UPPER(a.name) "
+                    + "= '" + value.toUpperCase() + "'", Field.class).getResultList();
+            if (!fields.isEmpty()) {
+                return fields.get(0);
+            }
+            return null;
+        } catch (Exception e) {
+            System.out.println(e);
+            return null;
+        }
+    }
+
+    public static Field findByCode(EntityManager em, String value) {
+
+        try {
+
+            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
+
+            List<Field> fields = em.createQuery("SELECT a FROM FieldField a "
+                    + "WHERE UPPER(a.code) "
+                    + "= '" + value.toUpperCase() + "'", Field.class).getResultList();
+            if (!fields.isEmpty()) {
+                return fields.get(0);
+            }
+            return null;
+        } catch (Exception e) {
+            System.out.println(e);
+            return null;
+        }
+    }
+
+    public static Field findActiveByCode(EntityManager em, String value) {
+
+        try {
+
+            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
+
+            List<Field> fields = em.createQuery("SELECT a FROM Field a "
+                    + "WHERE UPPER(a.code) "
+                    + "= '" + value.toUpperCase() + "' AND (a.active = 1 OR a.active IS NULL)", Field.class).getResultList();
+            if (!fields.isEmpty()) {
+                return fields.get(0);
+            }
+            return null;
+        } catch (Exception e) {
+            System.out.println(e);
+            return null;
+        }
+    }
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
@@ -122,65 +238,6 @@ public class Field implements Serializable, BusinessEntity {
 
     public void setCode(String code) {
         this.code = code;
-    }
-
-    public static List<Field> findAllFields(EntityManager em) {
-
-        try {
-            List<Field> codes = em.createNamedQuery("findAllFields", Field.class).getResultList();
-
-            return codes;
-
-        } catch (Exception e) {
-            System.out.println(e);
-            return null;
-        }
-    }
-
-    public static List<Field> findFields(EntityManager em, String value) {
-
-        try {
-
-            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
-
-            List<Field> fields
-                    = em.createQuery("SELECT a FROM Field a WHERE UPPER(a.name) LIKE '%" + value.toUpperCase().trim()
-                            + "%' OR UPPER(a.description) LIKE '%" + value.toUpperCase().trim()
-                            + "%' OR UPPER(a.code) LIKE '%" + value.toUpperCase().trim()
-                            + "%' OR UPPER(a.account) LIKE '%" + value.toUpperCase().trim()
-                            + "%' OR UPPER(a.type) LIKE '%" + value.toUpperCase().trim()
-                            + "%' OR UPPER(a.abbreviation) LIKE '%" + value.toUpperCase().trim()
-                            + "%' ORDER BY a.name",
-                            Field.class).getResultList();
-
-            return fields;
-
-        } catch (Exception e) {
-            System.out.println(e);
-            return new ArrayList<>();
-        }
-    }
-
-    public static List<Field> findActiveFields(EntityManager em, String value) {
-
-        try {
-
-            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
-
-            List<Field> fields
-                    = em.createQuery("SELECT a FROM Field a WHERE (UPPER(a.name) LIKE '%" + value.toUpperCase().trim()
-                            + "%' OR UPPER(a.description) LIKE '%" + value.toUpperCase().trim()
-                            + "%' OR UPPER(a.code) LIKE '%" + value.toUpperCase().trim()
-                            + "%' OR UPPER(a.account) LIKE '%" + value.toUpperCase().trim()
-                            + "%' OR UPPER(a.type) LIKE '%" + value.toUpperCase().trim()
-                            + "%' OR UPPER(a.abbreviation) LIKE '%" + value.toUpperCase().trim()
-                            + "%') AND (a.active = 1 OR a.active IS NULL) ORDER BY a.name",
-                            Field.class).getResultList();
-            return fields;
-        } catch (Exception e) {
-            System.out.println(e);
-            return new ArrayList<>();
-        }
     }
 
     @Override
@@ -280,73 +337,6 @@ public class Field implements Serializable, BusinessEntity {
         this.isDirty = isDirty;
     }
 
-    public static Field findByName(EntityManager em, String value) {
-
-        try {
-
-            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
-
-            List<Field> fields = em.createQuery("SELECT a FROM Field a "
-                    + "WHERE UPPER(a.name) "
-                    + "= '" + value.toUpperCase() + "'", Field.class).getResultList();
-            if (!fields.isEmpty()) {
-                return fields.get(0);
-            }
-            return null;
-        } catch (Exception e) {
-            System.out.println(e);
-            return null;
-        }
-    }
-
-    public static Field findByCode(EntityManager em, String value) {
-
-        try {
-
-            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
-
-            List<Field> fields = em.createQuery("SELECT a FROM FieldField a "
-                    + "WHERE UPPER(a.code) "
-                    + "= '" + value.toUpperCase() + "'", Field.class).getResultList();
-            if (!fields.isEmpty()) {
-                return fields.get(0);
-            }
-            return null;
-        } catch (Exception e) {
-            System.out.println(e);
-            return null;
-        }
-    }
-
-    public static Field findActiveByCode(EntityManager em, String value) {
-
-        try {
-
-            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
-
-            List<Field> fields = em.createQuery("SELECT a FROM Field a "
-                    + "WHERE UPPER(a.code) "
-                    + "= '" + value.toUpperCase() + "' AND (a.active = 1 OR a.active IS NULL)", Field.class).getResultList();
-            if (!fields.isEmpty()) {
-                return fields.get(0);
-            }
-            return null;
-        } catch (Exception e) {
-            System.out.println(e);
-            return null;
-        }
-    }
-
-    @Override
-    public Date getDateEntered() {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
-    }
-
-    @Override
-    public void setDateEntered(Date dateEntered) {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
-    }
-
     @Override
     public ReturnMessage delete(EntityManager em) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
@@ -369,16 +359,6 @@ public class Field implements Serializable, BusinessEntity {
 
     @Override
     public void setEnteredBy(Person person) {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
-    }
-
-    @Override
-    public Date getDateEdited() {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
-    }
-
-    @Override
-    public void setDateEdited(Date dateEdited) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
@@ -443,6 +423,26 @@ public class Field implements Serializable, BusinessEntity {
 
     @Override
     public void setSetting(String setting, String settingValue, String type, String category) {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public void setDateEntered(LocalDateTime dateEntered) {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public void setDateEdited(LocalDateTime dateEdited) {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public LocalDateTime getDateEntered() {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public LocalDateTime getDateEdited() {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 }

--- a/src/main/java/jm/com/dpbennett/business/entity/StatusNote.java
+++ b/src/main/java/jm/com/dpbennett/business/entity/StatusNote.java
@@ -19,23 +19,24 @@ Email: info@dpbennett.com.jm
  */
 package jm.com.dpbennett.business.entity;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.Transient;
 import java.io.Serializable;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EntityManager;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.NamedQueries;
-import javax.persistence.NamedQuery;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
-import javax.persistence.Temporal;
-import javax.persistence.Transient;
 import jm.com.dpbennett.business.entity.hrm.Employee;
 import jm.com.dpbennett.business.entity.sm.SystemOption;
 import jm.com.dpbennett.business.entity.util.BusinessEntityUtils;
@@ -54,6 +55,71 @@ import jm.com.dpbennett.business.entity.util.ReturnMessage;
 public class StatusNote implements Serializable, BusinessEntity {
 
     private static final long serialVersionUID = 1L;
+    public static List<StatusNote> findAllStatusNotes(EntityManager em) {
+        
+        try {
+            List<StatusNote> codes = em.createNamedQuery("findAllStatusNotes", StatusNote.class).getResultList();
+            
+            return codes;
+            
+        } catch (Exception e) {
+            System.out.println(e);
+            return null;
+        }
+    }
+    public static List<StatusNote> findstatusNotes(EntityManager em, String value) {
+        
+        try {
+            
+            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
+            
+            List<StatusNote> statusNotes
+                    = em.createQuery("SELECT s FROM StatusNote s WHERE UPPER(s.text) LIKE '%" + value.toUpperCase().trim()
+                            + "%' OR UPPER(s.description) LIKE '%" + value.toUpperCase().trim()
+                            + "%' OR UPPER(s.code) LIKE '%" + value.toUpperCase().trim()
+                            + "%' OR UPPER(s.type) LIKE '%" + value.toUpperCase().trim()
+                            + "%' ORDER BY s.dateCreated DESC",
+                            StatusNote.class).getResultList();
+            return statusNotes;
+        } catch (Exception e) {
+            System.out.println(e);
+            return new ArrayList<>();
+        }
+    }
+    public static List<StatusNote> findActiveStatusNotes(EntityManager em, String value) {
+        
+        try {
+            
+            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
+            
+            List<StatusNote> statusNotes
+                    = em.createQuery("SELECT s FROM StatusNote s WHERE (UPPER(s.text) LIKE '%" + value.toUpperCase().trim()
+                            + "%' OR UPPER(s.description) LIKE '%" + value.toUpperCase().trim()
+                            + "%' OR UPPER(s.code) LIKE '%" + value.toUpperCase().trim()
+                            + "%' OR UPPER(s.type) LIKE '%" + value.toUpperCase().trim()
+                            + "%') AND (s.active = 1 OR s.active IS NULL) ORDER BY s.dateCreated DESC",
+                            StatusNote.class).getResultList();
+            return statusNotes;
+        } catch (Exception e) {
+            System.out.println(e);
+            return new ArrayList<>();
+        }
+    }
+    public static List<StatusNote> findActiveStatusNotesByEntityId(EntityManager em, Long entityId) {
+        
+        try {
+            
+            List<StatusNote> statusNotes
+                    = em.createQuery("SELECT s FROM StatusNote s WHERE"
+                            + " s.entityId = " + entityId
+                            + " AND (s.active = 1 OR s.active IS NULL) ORDER BY s.id DESC",
+                            StatusNote.class).getResultList();
+            return statusNotes;
+        } catch (Exception e) {
+            System.out.println(e);
+            return new ArrayList<>();
+        }
+    }
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
@@ -69,7 +135,6 @@ public class StatusNote implements Serializable, BusinessEntity {
     private String category;
     @Transient
     private Boolean isDirty;
-    @Temporal(javax.persistence.TemporalType.DATE)
     private Date dateCreated;
     @OneToOne(cascade = CascadeType.REFRESH)
     private Employee createdBy;
@@ -185,74 +250,6 @@ public class StatusNote implements Serializable, BusinessEntity {
         this.code = code;
     }
 
-    public static List<StatusNote> findAllStatusNotes(EntityManager em) {
-
-        try {
-            List<StatusNote> codes = em.createNamedQuery("findAllStatusNotes", StatusNote.class).getResultList();
-
-            return codes;
-
-        } catch (Exception e) {
-            System.out.println(e);
-            return null;
-        }
-    }
-
-    public static List<StatusNote> findstatusNotes(EntityManager em, String value) {
-
-        try {
-
-            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
-
-            List<StatusNote> statusNotes
-                    = em.createQuery("SELECT s FROM StatusNote s WHERE UPPER(s.text) LIKE '%" + value.toUpperCase().trim()
-                            + "%' OR UPPER(s.description) LIKE '%" + value.toUpperCase().trim()
-                            + "%' OR UPPER(s.code) LIKE '%" + value.toUpperCase().trim()
-                            + "%' OR UPPER(s.type) LIKE '%" + value.toUpperCase().trim()
-                            + "%' ORDER BY s.dateCreated DESC",
-                            StatusNote.class).getResultList();
-            return statusNotes;
-        } catch (Exception e) {
-            System.out.println(e);
-            return new ArrayList<>();
-        }
-    }
-
-    public static List<StatusNote> findActiveStatusNotes(EntityManager em, String value) {
-
-        try {
-
-            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
-
-            List<StatusNote> statusNotes
-                    = em.createQuery("SELECT s FROM StatusNote s WHERE (UPPER(s.text) LIKE '%" + value.toUpperCase().trim()
-                            + "%' OR UPPER(s.description) LIKE '%" + value.toUpperCase().trim()
-                            + "%' OR UPPER(s.code) LIKE '%" + value.toUpperCase().trim()
-                            + "%' OR UPPER(s.type) LIKE '%" + value.toUpperCase().trim()
-                            + "%') AND (s.active = 1 OR s.active IS NULL) ORDER BY s.dateCreated DESC",
-                            StatusNote.class).getResultList();
-            return statusNotes;
-        } catch (Exception e) {
-            System.out.println(e);
-            return new ArrayList<>();
-        }
-    }
-
-    public static List<StatusNote> findActiveStatusNotesByEntityId(EntityManager em, Long entityId) {
-
-        try {
-
-            List<StatusNote> statusNotes
-                    = em.createQuery("SELECT s FROM StatusNote s WHERE"
-                            + " s.entityId = " + entityId
-                            + " AND (s.active = 1 OR s.active IS NULL) ORDER BY s.id DESC",
-                            StatusNote.class).getResultList();
-            return statusNotes;
-        } catch (Exception e) {
-            System.out.println(e);
-            return new ArrayList<>();
-        }
-    }
 
     @Override
     public Long getId() {
@@ -356,16 +353,6 @@ public class StatusNote implements Serializable, BusinessEntity {
     }
 
     @Override
-    public Date getDateEntered() {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
-    }
-
-    @Override
-    public void setDateEntered(Date dateEntered) {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
-    }
-
-    @Override
     public ReturnMessage delete(EntityManager em) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
@@ -387,16 +374,6 @@ public class StatusNote implements Serializable, BusinessEntity {
 
     @Override
     public void setEnteredBy(Person person) {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
-    }
-
-    @Override
-    public Date getDateEdited() {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
-    }
-
-    @Override
-    public void setDateEdited(Date dateEdited) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
@@ -444,5 +421,26 @@ public class StatusNote implements Serializable, BusinessEntity {
     public void setSetting(String setting, String settingValue, String type, String category) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
+
+    @Override
+    public void setDateEntered(LocalDateTime dateEntered) {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public void setDateEdited(LocalDateTime dateEdited) {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public LocalDateTime getDateEntered() {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public LocalDateTime getDateEdited() {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+    private static final System.Logger LOG = System.getLogger(StatusNote.class.getName());
 
 }

--- a/src/main/java/jm/com/dpbennett/business/entity/TestEntity.java
+++ b/src/main/java/jm/com/dpbennett/business/entity/TestEntity.java
@@ -19,9 +19,9 @@ Email: info@dpbennett.com.jm
  */
 package jm.com.dpbennett.business.entity;
 
-import java.util.Date;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
 import java.util.List;
-import javax.persistence.EntityManager;
 import jm.com.dpbennett.business.entity.sm.SystemOption;
 import jm.com.dpbennett.business.entity.util.ReturnMessage;
 
@@ -31,8 +31,10 @@ import jm.com.dpbennett.business.entity.util.ReturnMessage;
  */
 public class TestEntity implements Account {
 
+    private static final long serialVersionUID = 1L;
+    private static final System.Logger LOG = System.getLogger(TestEntity.class.getName());
+
     public static void main(String[] args) {
-        System.out.println("Yes iyah!");
     }
 
     @Override
@@ -96,16 +98,6 @@ public class TestEntity implements Account {
     }
 
     @Override
-    public Date getDateEntered() {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
-    }
-
-    @Override
-    public void setDateEntered(Date dateEntered) {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
-    }
-
-    @Override
     public ReturnMessage delete(EntityManager em) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
@@ -137,16 +129,6 @@ public class TestEntity implements Account {
 
     @Override
     public void setEnteredBy(Person person) {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
-    }
-
-    @Override
-    public Date getDateEdited() {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
-    }
-
-    @Override
-    public void setDateEdited(Date dateEdited) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
@@ -202,6 +184,26 @@ public class TestEntity implements Account {
 
     @Override
     public void setSetting(String setting, String settingValue, String type, String category) {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public void setDateEntered(LocalDateTime dateEntered) {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public void setDateEdited(LocalDateTime dateEdited) {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public LocalDateTime getDateEntered() {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public LocalDateTime getDateEdited() {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 }

--- a/src/main/java/jm/com/dpbennett/business/entity/auth/LdapContext.java
+++ b/src/main/java/jm/com/dpbennett/business/entity/auth/LdapContext.java
@@ -20,8 +20,17 @@ Email: info@dpbennett.com.jm
 
 package jm.com.dpbennett.business.entity.auth;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Properties;
@@ -35,15 +44,6 @@ import javax.naming.directory.DirContext;
 import javax.naming.directory.InitialDirContext;
 import javax.naming.directory.ModificationItem;
 import javax.naming.ldap.InitialLdapContext;
-import javax.persistence.Entity;
-import javax.persistence.EntityManager;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.NamedQueries;
-import javax.persistence.NamedQuery;
-import javax.persistence.Table;
-import javax.persistence.Transient;
 import jm.com.dpbennett.business.entity.BusinessEntity;
 import jm.com.dpbennett.business.entity.Person;
 import jm.com.dpbennett.business.entity.sm.SystemOption;
@@ -66,6 +66,247 @@ import jm.com.dpbennett.business.entity.util.Security;
 public class LdapContext implements BusinessEntity {
 
     private static final long serialVersionUID = 1L;
+    private static final System.Logger LOG = System.getLogger(LdapContext.class.getName());
+    public static List<LdapContext> findAllLdapContexts(EntityManager em) {
+        
+        try {
+            return em.createNamedQuery("findAllLdapContexts", LdapContext.class).getResultList();
+        } catch (Exception e) {
+            System.out.println(e);
+            return new ArrayList<>();
+        }
+    }
+    public static List<LdapContext> findAllActiveLdapContexts(EntityManager em) {
+        
+        try {
+            return em.createNamedQuery("findAllActiveLdapContexts", LdapContext.class).getResultList();
+        } catch (Exception e) {
+            System.out.println(e);
+            return new ArrayList<>();
+        }
+    }
+    public static List<LdapContext> findActiveLdapContexts(
+            EntityManager em, String value) {
+        
+        try {
+            
+            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
+            
+            List<LdapContext> ldapContexts
+                    = em.createQuery("SELECT l FROM LdapContext l WHERE "
+                            + "( UPPER(l.name) LIKE '%" + value + "%'"
+                                    + " OR UPPER(l.domainName) like '%" + value + "%'"
+                                            + " OR UPPER(l.initialContextFactory) like '%" + value + "%'"
+                                                    + " OR UPPER(l.providerUrl) LIKE '%" + value + "%'"
+                                                            + ") AND l.active = 1 ORDER BY l.name", LdapContext.class).getResultList();
+            
+            return ldapContexts;
+            
+        } catch (Exception e) {
+            System.out.println(e);
+            return new ArrayList<>();
+        }
+    }
+    public static List<LdapContext> findLdapContexts(
+            EntityManager em, String value) {
+        
+        try {
+            
+            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
+            
+            List<LdapContext> ldapContexts
+                    = em.createQuery("SELECT l FROM LdapContext l WHERE "
+                            + "UPPER(l.name) LIKE '%" + value + "%'"
+                                    + " OR UPPER(l.domainName) like '%" + value + "%'"
+                                            + " OR UPPER(l.initialContextFactory) like '%" + value + "%'"
+                                                    + " OR UPPER(l.providerUrl) LIKE '%" + value + "%'"
+                                                            + " ORDER BY l.name", LdapContext.class).getResultList();
+            
+            return ldapContexts;
+            
+        } catch (Exception e) {
+            System.out.println(e);
+            return new ArrayList<>();
+        }
+    }
+    public static LdapContext findActiveLdapContextByName(
+            EntityManager em, String value) {
+        
+        try {
+            
+            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
+            
+            List<LdapContext> ldapContexts = em.createQuery("SELECT l FROM LdapContext l "
+                    + "WHERE l.active = 1 AND UPPER(l.name) "
+                    + "= '" + value.toUpperCase() + "'", LdapContext.class).getResultList();
+            if (!ldapContexts.isEmpty()) {
+                return ldapContexts.get(0);
+            }
+            return null;
+        } catch (Exception e) {
+            System.out.println(e);
+            return null;
+        }
+    }
+    public static DirContext getConnection(EntityManager em, String name) {
+        LdapContext context = LdapContext.findActiveLdapContextByName(em, name);
+        Properties env = new Properties();
+        
+        env.put(Context.INITIAL_CONTEXT_FACTORY, context.initialContextFactory);
+        env.put(Context.PROVIDER_URL, context.providerUrl);
+        env.put(Context.SECURITY_PRINCIPAL, context.securityPrincipal);
+        env.put(Context.SECURITY_CREDENTIALS, context.securityCredentials);
+        
+        try {
+            return new InitialDirContext(env);
+            
+        } catch (NamingException ex) {
+            System.out.println(ex);
+        }
+        
+        return null;
+    }
+    public static DirContext getConnection(LdapContext context) {
+        
+        Properties env = new Properties();
+        
+        env.put(Context.INITIAL_CONTEXT_FACTORY, context.initialContextFactory);
+        env.put(Context.PROVIDER_URL, context.providerUrl);
+        env.put(Context.SECURITY_PRINCIPAL, context.securityPrincipal);
+        env.put(Context.SECURITY_CREDENTIALS, context.securityCredentials);
+        
+        try {
+            return new InitialDirContext(env);
+            
+        } catch (NamingException ex) {
+            System.out.println(ex);
+        }
+        
+        return null;
+    }
+    public static boolean addUser(
+            EntityManager em,
+            LdapContext context,
+            User user) {
+        
+        String securityKey = SystemOption.getString(em, "securityKey");
+        Attributes attributes = new BasicAttributes();
+        Attribute inetOrgPerson = new BasicAttribute("objectClass");
+        
+        inetOrgPerson.add("inetOrgPerson");
+        
+        attributes.put(inetOrgPerson);
+        attributes.put("uid", user.getUsername());
+        attributes.put("userPassword", Security.encrypt(securityKey, user.getPassword()));
+        attributes.put("cn", user.getEmployeeFirstname());
+        attributes.put("sn", user.getEmployeeLastname());
+        
+        try {
+            DirContext connection = getConnection(context);
+            
+            if (connection != null) {
+                connection.createSubcontext(
+                        "uid=" + user.getUsername() + "," + context.domainName,
+                        attributes);
+                
+                return true;
+            }
+            
+        } catch (NamingException ex) {
+            System.out.println(ex);
+        }
+        
+        return false;
+        
+    }
+    public static boolean authenticateUser(
+            EntityManager em,
+            LdapContext context,
+            String userName,
+            String userPassword) {
+        
+        try {
+            
+            String securityKey = SystemOption.getString(em, "securityKey");
+            Properties env = new Properties();
+            
+            env.put(Context.INITIAL_CONTEXT_FACTORY, context.initialContextFactory);
+            env.put(Context.PROVIDER_URL, context.providerUrl);
+            env.put(Context.SECURITY_PRINCIPAL, "uid=" + userName + ","
+                    + context.domainName);
+            env.put(Context.SECURITY_CREDENTIALS,
+                    Security.encrypt(securityKey, userPassword));
+            
+            DirContext con = new InitialDirContext(env);
+            con.close();
+            
+            return true;
+            
+        } catch (NamingException ex) {
+            System.out.println(ex);
+        }
+        
+        return false;
+        
+    }
+    public static boolean updateUserPassword(
+            EntityManager em,
+            LdapContext context,
+            String userName,
+            String password) {
+        
+        String securityKey = SystemOption.getString(em, "securityKey");
+        ModificationItem[] mods = new ModificationItem[1];
+        mods[0] = new ModificationItem(DirContext.REPLACE_ATTRIBUTE,
+                new BasicAttribute("userPassword", Security.encrypt(securityKey, password)));
+        
+        try {
+            DirContext connection = getConnection(context);
+            
+            if (connection != null) {
+                connection.modifyAttributes(
+                        "uid=" + userName + "," + context.domainName,
+                        mods);
+                
+                return true;
+            }
+            
+        } catch (NamingException ex) {
+            System.out.println(ex);
+        }
+        
+        return false;
+        
+    }
+    public static boolean updateUser(
+            LdapContext context,
+            User user) {
+        
+        ModificationItem[] mods = new ModificationItem[2];
+        
+        mods[0] = new ModificationItem(DirContext.REPLACE_ATTRIBUTE,
+                new BasicAttribute("cn", user.getEmployeeFirstname()));
+        mods[1] = new ModificationItem(DirContext.REPLACE_ATTRIBUTE,
+                new BasicAttribute("sn", user.getEmployeeLastname()));
+        
+        try {
+            DirContext connection = getConnection(context);
+            
+            if (connection != null) {
+                connection.modifyAttributes(
+                        "uid=" + user.getUsername() + "," + context.domainName,
+                        mods);
+                
+                return true;
+            }
+            
+        } catch (NamingException ex) {
+            System.out.println(ex);
+        }
+        
+        return false;
+        
+    }
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
@@ -232,71 +473,6 @@ public class LdapContext implements BusinessEntity {
         this.name = name;
     }
 
-    public static List<LdapContext> findAllLdapContexts(EntityManager em) {
-
-        try {
-            return em.createNamedQuery("findAllLdapContexts", LdapContext.class).getResultList();
-        } catch (Exception e) {
-            System.out.println(e);
-            return new ArrayList<>();
-        }
-    }
-
-    public static List<LdapContext> findAllActiveLdapContexts(EntityManager em) {
-
-        try {
-            return em.createNamedQuery("findAllActiveLdapContexts", LdapContext.class).getResultList();
-        } catch (Exception e) {
-            System.out.println(e);
-            return new ArrayList<>();
-        }
-    }
-
-    public static List<LdapContext> findActiveLdapContexts(
-            EntityManager em, String value) {
-
-        try {
-
-            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
-
-            List<LdapContext> ldapContexts
-                    = em.createQuery("SELECT l FROM LdapContext l WHERE "
-                            + "( UPPER(l.name) LIKE '%" + value + "%'"
-                            + " OR UPPER(l.domainName) like '%" + value + "%'"
-                            + " OR UPPER(l.initialContextFactory) like '%" + value + "%'"
-                            + " OR UPPER(l.providerUrl) LIKE '%" + value + "%'"
-                            + ") AND l.active = 1 ORDER BY l.name", LdapContext.class).getResultList();
-
-            return ldapContexts;
-
-        } catch (Exception e) {
-            System.out.println(e);
-            return new ArrayList<>();
-        }
-    }
-
-    public static List<LdapContext> findLdapContexts(
-            EntityManager em, String value) {
-
-        try {
-
-            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
-
-            List<LdapContext> ldapContexts
-                    = em.createQuery("SELECT l FROM LdapContext l WHERE "
-                            + "UPPER(l.name) LIKE '%" + value + "%'"
-                            + " OR UPPER(l.domainName) like '%" + value + "%'"
-                            + " OR UPPER(l.initialContextFactory) like '%" + value + "%'"
-                            + " OR UPPER(l.providerUrl) LIKE '%" + value + "%'"
-                            + " ORDER BY l.name", LdapContext.class).getResultList();
-
-            return ldapContexts;
-
-        } catch (Exception e) {
-            System.out.println(e);
-            return new ArrayList<>();
-        }
-    }
 
     public InitialLdapContext getInitialLDAPContext(String username, String password) {
 
@@ -340,190 +516,6 @@ public class LdapContext implements BusinessEntity {
         return new ReturnMessage();
     }
 
-    public static LdapContext findActiveLdapContextByName(
-            EntityManager em, String value) {
-
-        try {
-
-            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
-
-            List<LdapContext> ldapContexts = em.createQuery("SELECT l FROM LdapContext l "
-                    + "WHERE l.active = 1 AND UPPER(l.name) "
-                    + "= '" + value.toUpperCase() + "'", LdapContext.class).getResultList();
-            if (!ldapContexts.isEmpty()) {
-                return ldapContexts.get(0);
-            }
-            return null;
-        } catch (Exception e) {
-            System.out.println(e);
-            return null;
-        }
-    }
-
-    public static DirContext getConnection(EntityManager em, String name) {
-        LdapContext context = LdapContext.findActiveLdapContextByName(em, name);
-        Properties env = new Properties();
-
-        env.put(Context.INITIAL_CONTEXT_FACTORY, context.initialContextFactory);
-        env.put(Context.PROVIDER_URL, context.providerUrl);
-        env.put(Context.SECURITY_PRINCIPAL, context.securityPrincipal);
-        env.put(Context.SECURITY_CREDENTIALS, context.securityCredentials);
-
-        try {
-            return new InitialDirContext(env);
-
-        } catch (NamingException ex) {
-            System.out.println(ex);
-        }
-
-        return null;
-    }
-
-    public static DirContext getConnection(LdapContext context) {
-
-        Properties env = new Properties();
-
-        env.put(Context.INITIAL_CONTEXT_FACTORY, context.initialContextFactory);
-        env.put(Context.PROVIDER_URL, context.providerUrl);
-        env.put(Context.SECURITY_PRINCIPAL, context.securityPrincipal);
-        env.put(Context.SECURITY_CREDENTIALS, context.securityCredentials);
-
-        try {
-            return new InitialDirContext(env);
-
-        } catch (NamingException ex) {
-            System.out.println(ex);
-        }
-
-        return null;
-    }
-
-    public static boolean addUser(
-            EntityManager em,
-            LdapContext context,
-            User user) {
-
-        String securityKey = SystemOption.getString(em, "securityKey");
-        Attributes attributes = new BasicAttributes();
-        Attribute inetOrgPerson = new BasicAttribute("objectClass");
-
-        inetOrgPerson.add("inetOrgPerson");
-
-        attributes.put(inetOrgPerson);
-        attributes.put("uid", user.getUsername());
-        attributes.put("userPassword", Security.encrypt(securityKey, user.getPassword()));
-        attributes.put("cn", user.getEmployeeFirstname());
-        attributes.put("sn", user.getEmployeeLastname());
-
-        try {
-            DirContext connection = getConnection(context);
-
-            if (connection != null) {
-                connection.createSubcontext(
-                        "uid=" + user.getUsername() + "," + context.domainName,
-                        attributes);
-
-                return true;
-            }
-
-        } catch (NamingException ex) {
-            System.out.println(ex);
-        }
-
-        return false;
-
-    }
-
-    public static boolean authenticateUser(
-            EntityManager em,
-            LdapContext context,
-            String userName,
-            String userPassword) {
-
-        try {
-
-            String securityKey = SystemOption.getString(em, "securityKey");
-            Properties env = new Properties();
-
-            env.put(Context.INITIAL_CONTEXT_FACTORY, context.initialContextFactory);
-            env.put(Context.PROVIDER_URL, context.providerUrl);
-            env.put(Context.SECURITY_PRINCIPAL, "uid=" + userName + ","
-                    + context.domainName);
-            env.put(Context.SECURITY_CREDENTIALS,
-                    Security.encrypt(securityKey, userPassword));
-
-            DirContext con = new InitialDirContext(env);
-            con.close();
-
-            return true;
-
-        } catch (NamingException ex) {
-            System.out.println(ex);
-        }
-
-        return false;
-
-    }
-
-    public static boolean updateUserPassword(
-            EntityManager em,
-            LdapContext context,
-            String userName,
-            String password) {
-
-        String securityKey = SystemOption.getString(em, "securityKey");
-        ModificationItem[] mods = new ModificationItem[1];
-        mods[0] = new ModificationItem(DirContext.REPLACE_ATTRIBUTE,
-                new BasicAttribute("userPassword", Security.encrypt(securityKey, password)));
-
-        try {
-            DirContext connection = getConnection(context);
-
-            if (connection != null) {
-                connection.modifyAttributes(
-                        "uid=" + userName + "," + context.domainName,
-                        mods);
-
-                return true;
-            }
-
-        } catch (NamingException ex) {
-            System.out.println(ex);
-        }
-
-        return false;
-
-    }
-
-    public static boolean updateUser(
-            LdapContext context,
-            User user) {
-
-        ModificationItem[] mods = new ModificationItem[2];
-
-        mods[0] = new ModificationItem(DirContext.REPLACE_ATTRIBUTE,
-                new BasicAttribute("cn", user.getEmployeeFirstname()));
-        mods[1] = new ModificationItem(DirContext.REPLACE_ATTRIBUTE,
-                new BasicAttribute("sn", user.getEmployeeLastname()));
-
-        try {
-            DirContext connection = getConnection(context);
-
-            if (connection != null) {
-                connection.modifyAttributes(
-                        "uid=" + user.getUsername() + "," + context.domainName,
-                        mods);
-
-                return true;
-            }
-
-        } catch (NamingException ex) {
-            System.out.println(ex);
-        }
-
-        return false;
-
-    }
 
     @Override
     public String getType() {
@@ -542,26 +534,6 @@ public class LdapContext implements BusinessEntity {
 
     @Override
     public void setCategory(String category) {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
-    }
-
-    @Override
-    public Date getDateEntered() {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
-    }
-
-    @Override
-    public void setDateEntered(Date dateEntered) {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
-    }
-
-    @Override
-    public Date getDateEdited() {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
-    }
-
-    @Override
-    public void setDateEdited(Date dateEdited) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
@@ -642,6 +614,26 @@ public class LdapContext implements BusinessEntity {
 
     @Override
     public void setSetting(String setting, String settingValue, String type, String category) {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public LocalDateTime getDateEntered() {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public void setDateEntered(LocalDateTime dateEntered) {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public LocalDateTime getDateEdited() {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public void setDateEdited(LocalDateTime dateEdited) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 }

--- a/src/main/java/jm/com/dpbennett/business/entity/auth/Privilege.java
+++ b/src/main/java/jm/com/dpbennett/business/entity/auth/Privilege.java
@@ -19,18 +19,19 @@ Email: info@dpbennett.com.jm
  */
 package jm.com.dpbennett.business.entity.auth;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import java.io.Serializable;
+import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.List;
-import javax.persistence.Entity;
-import javax.persistence.EntityManager;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.NamedQueries;
-import javax.persistence.NamedQuery;
-import javax.persistence.Table;
-import javax.persistence.Transient;
 import jm.com.dpbennett.business.entity.Person;
 import jm.com.dpbennett.business.entity.sm.SystemOption;
 import jm.com.dpbennett.business.entity.util.BusinessEntityUtils;
@@ -49,6 +50,85 @@ import jm.com.dpbennett.business.entity.util.ReturnMessage;
 public class Privilege implements Serializable, PrivilegeInterface {
 
     private static final long serialVersionUID = 1L;
+    private static final System.Logger LOG = System.getLogger(Privilege.class.getName());
+    public static Privilege findActiveByName(EntityManager em, String value) {
+        
+        try {
+            
+            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
+            
+            List<Privilege> privileges = em.createQuery("SELECT p FROM Privilege p "
+                    + "WHERE p.active = 1 AND UPPER(p.name) "
+                    + "= '" + value.toUpperCase() + "'", Privilege.class).getResultList();
+            if (!privileges.isEmpty()) {
+                return privileges.get(0);
+            }
+            return null;
+        } catch (Exception e) {
+            System.out.println(e);
+            return null;
+        }
+    }
+    public static List<Privilege> findAllActive(EntityManager em, String query) {
+        try {
+            
+            query = query.replaceAll("&amp;", "&").replaceAll("'", "`");
+            
+            List<Privilege> privileges = em.createQuery("SELECT p FROM Privilege p"
+                    + " WHERE (p.active = 1) AND (UPPER(p.name) like '%"
+                    + query + "%'" + " OR UPPER(p.category) like '%"
+                    + query + "%'" + " OR UPPER(p.description) like '%"
+                    + query + "%') ORDER BY p.name", Privilege.class).getResultList();
+            
+            return privileges;
+            
+        } catch (Exception e) {
+            System.out.println(e);
+            return null;
+        }
+    }
+    public static Privilege findByName(EntityManager em, String name) {
+        
+        try {
+            
+            name = name.replaceAll("&amp;", "&").replaceAll("'", "`");
+            
+            List<Privilege> privileges = em.createQuery("SELECT p FROM Privilege p "
+                    + "WHERE UPPER(p.name) "
+                    + "LIKE '" + name.toUpperCase() + "%'", Privilege.class).getResultList();
+            
+            if (!privileges.isEmpty()) {
+                
+                Privilege privilege = privileges.get(0);
+                em.refresh(privilege);
+                
+                return privilege;
+            }
+            
+            return null;
+        } catch (Exception e) {
+            System.out.println(e);
+            return null;
+        }
+    }
+    public static List<Privilege> findPrivileges(EntityManager em, String query) {
+        try {
+            
+            query = query.replaceAll("&amp;", "&").replaceAll("'", "`");
+            
+            List<Privilege> privileges = em.createQuery("SELECT p FROM Privilege p"
+                    + " WHERE (UPPER(p.name) like '%"
+                    + query + "%'" + " OR UPPER(p.category) like '%"
+                    + query + "%'" + " OR UPPER(p.description) like '%"
+                    + query + "%') ORDER BY p.name", Privilege.class).getResultList();
+            
+            return privileges;
+            
+        } catch (Exception e) {
+            System.out.println(e);
+            return null;
+        }
+    }
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
@@ -157,87 +237,6 @@ public class Privilege implements Serializable, PrivilegeInterface {
         this.name = name;
     }
 
-    public static Privilege findActiveByName(EntityManager em, String value) {
-
-        try {
-
-            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
-
-            List<Privilege> privileges = em.createQuery("SELECT p FROM Privilege p "
-                    + "WHERE p.active = 1 AND UPPER(p.name) "
-                    + "= '" + value.toUpperCase() + "'", Privilege.class).getResultList();
-            if (!privileges.isEmpty()) {
-                return privileges.get(0);
-            }
-            return null;
-        } catch (Exception e) {
-            System.out.println(e);
-            return null;
-        }
-    }
-
-    public static List<Privilege> findAllActive(EntityManager em, String query) {
-        try {
-
-            query = query.replaceAll("&amp;", "&").replaceAll("'", "`");
-
-            List<Privilege> privileges = em.createQuery("SELECT p FROM Privilege p"
-                    + " WHERE (p.active = 1) AND (UPPER(p.name) like '%"
-                    + query + "%'" + " OR UPPER(p.category) like '%"
-                    + query + "%'" + " OR UPPER(p.description) like '%"
-                    + query + "%') ORDER BY p.name", Privilege.class).getResultList();
-
-            return privileges;
-
-        } catch (Exception e) {
-            System.out.println(e);
-            return null;
-        }
-    }
-
-    public static Privilege findByName(EntityManager em, String name) {
-
-        try {
-
-            name = name.replaceAll("&amp;", "&").replaceAll("'", "`");
-
-            List<Privilege> privileges = em.createQuery("SELECT p FROM Privilege p "
-                    + "WHERE UPPER(p.name) "
-                    + "LIKE '" + name.toUpperCase() + "%'", Privilege.class).getResultList();
-
-            if (!privileges.isEmpty()) {
-
-                Privilege privilege = privileges.get(0);
-                em.refresh(privilege);
-
-                return privilege;
-            }
-
-            return null;
-        } catch (Exception e) {
-            System.out.println(e);
-            return null;
-        }
-    }
-
-    public static List<Privilege> findPrivileges(EntityManager em, String query) {
-        try {
-
-            query = query.replaceAll("&amp;", "&").replaceAll("'", "`");
-
-            List<Privilege> privileges = em.createQuery("SELECT p FROM Privilege p"
-                    + " WHERE (UPPER(p.name) like '%"
-                    + query + "%'" + " OR UPPER(p.category) like '%"
-                    + query + "%'" + " OR UPPER(p.description) like '%"
-                    + query + "%') ORDER BY p.name", Privilege.class).getResultList();
-
-            return privileges;
-
-        } catch (Exception e) {
-            System.out.println(e);
-            return null;
-        }
-    }
 
     @Override
     public Boolean getActive() {
@@ -250,26 +249,6 @@ public class Privilege implements Serializable, PrivilegeInterface {
     @Override
     public void setActive(Boolean active) {
         this.active = active;
-    }
-
-    @Override
-    public Date getDateEntered() {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
-    }
-
-    @Override
-    public void setDateEntered(Date dateEntered) {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
-    }
-
-    @Override
-    public Date getDateEdited() {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
-    }
-
-    @Override
-    public void setDateEdited(Date dateEdited) {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
@@ -391,6 +370,26 @@ public class Privilege implements Serializable, PrivilegeInterface {
 
     @Override
     public void setSetting(String setting, String settingValue, String type, String category) {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public void setDateEntered(LocalDateTime dateEntered) {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public void setDateEdited(LocalDateTime dateEdited) {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public LocalDateTime getDateEntered() {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public LocalDateTime getDateEdited() {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 }

--- a/src/main/java/jm/com/dpbennett/business/entity/auth/PrivilegeLegacy.java
+++ b/src/main/java/jm/com/dpbennett/business/entity/auth/PrivilegeLegacy.java
@@ -20,18 +20,19 @@ Email: info@dpbennett.com.jm
 
 package jm.com.dpbennett.business.entity.auth;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import java.io.Serializable;
+import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.List;
-import javax.persistence.Entity;
-import javax.persistence.EntityManager;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.NamedQueries;
-import javax.persistence.NamedQuery;
-import javax.persistence.Table;
-import javax.persistence.Transient;
 import jm.com.dpbennett.business.entity.Person;
 import jm.com.dpbennett.business.entity.sm.SystemOption;
 import jm.com.dpbennett.business.entity.util.BusinessEntityUtils;
@@ -550,26 +551,6 @@ public class PrivilegeLegacy implements Serializable, PrivilegeInterface {
     }
 
     @Override
-    public Date getDateEntered() {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
-    }
-
-    @Override
-    public void setDateEntered(Date dateEntered) {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
-    }
-
-    @Override
-    public Date getDateEdited() {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
-    }
-
-    @Override
-    public void setDateEdited(Date dateEdited) {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
-    }
-
-    @Override
     public ReturnMessage save(EntityManager em) {
 
         try {
@@ -688,6 +669,26 @@ public class PrivilegeLegacy implements Serializable, PrivilegeInterface {
 
     @Override
     public void setSetting(String setting, String settingValue, String type, String category) {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public LocalDateTime getDateEntered() {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public void setDateEntered(LocalDateTime dateEntered) {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public LocalDateTime getDateEdited() {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public void setDateEdited(LocalDateTime dateEdited) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 }

--- a/src/main/java/jm/com/dpbennett/business/entity/auth/Signature.java
+++ b/src/main/java/jm/com/dpbennett/business/entity/auth/Signature.java
@@ -19,17 +19,18 @@ Email: info@dpbennett.com.jm
  */
 package jm.com.dpbennett.business.entity.auth;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import java.io.Serializable;
+import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.List;
-import javax.persistence.Entity;
-import javax.persistence.EntityManager;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Lob;
-import javax.persistence.Table;
-import javax.persistence.Transient;
 import jm.com.dpbennett.business.entity.BusinessEntity;
 import jm.com.dpbennett.business.entity.Person;
 import jm.com.dpbennett.business.entity.sm.SystemOption;
@@ -45,6 +46,10 @@ import jm.com.dpbennett.business.entity.util.ReturnMessage;
 public class Signature implements Serializable, BusinessEntity {
 
     private static final long serialVersionUID = 1L;
+    private static final System.Logger LOG = System.getLogger(Signature.class.getName());
+    public static Signature findSignatureById(EntityManager em, Long Id) {
+        return em.find(Signature.class, Id);
+    }
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
@@ -54,15 +59,6 @@ public class Signature implements Serializable, BusinessEntity {
     @Transient
     private Boolean isDirty;
 
-    @Override
-    public Long getId() {
-        return id;
-    }
-
-    @Override
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public Signature() {
         this.name = "";
@@ -75,6 +71,14 @@ public class Signature implements Serializable, BusinessEntity {
     public Signature(String name, byte[] signatureImage) {
         this.name = name;
         this.signatureImage = signatureImage;
+    }
+    @Override
+    public Long getId() {
+        return id;
+    }
+    @Override
+    public void setId(Long id) {
+        this.id = id;
     }
 
     @Override
@@ -131,9 +135,6 @@ public class Signature implements Serializable, BusinessEntity {
         this.name = name;
     }
 
-    public static Signature findSignatureById(EntityManager em, Long Id) {
-        return em.find(Signature.class, Id);
-    }
 
     @Override
     public ReturnMessage save(EntityManager em) {
@@ -178,16 +179,6 @@ public class Signature implements Serializable, BusinessEntity {
     }
 
     @Override
-    public Date getDateEntered() {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
-    }
-
-    @Override
-    public void setDateEntered(Date dateEntered) {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
-    }
-
-    @Override
     public ReturnMessage delete(EntityManager em) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
@@ -219,16 +210,6 @@ public class Signature implements Serializable, BusinessEntity {
 
     @Override
     public void setEnteredBy(Person person) {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
-    }
-
-    @Override
-    public Date getDateEdited() {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
-    }
-
-    @Override
-    public void setDateEdited(Date dateEdited) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
@@ -284,6 +265,26 @@ public class Signature implements Serializable, BusinessEntity {
 
     @Override
     public void setSetting(String setting, String settingValue, String type, String category) {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public void setDateEntered(LocalDateTime dateEntered) {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public void setDateEdited(LocalDateTime dateEdited) {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public LocalDateTime getDateEntered() {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public LocalDateTime getDateEdited() {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 }

--- a/src/main/java/jm/com/dpbennett/business/entity/cert/Certification.java
+++ b/src/main/java/jm/com/dpbennett/business/entity/cert/Certification.java
@@ -19,21 +19,21 @@ Email: info@dpbennett.com.jm
  */
 package jm.com.dpbennett.business.entity.cert;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import jm.com.dpbennett.business.entity.hrm.Business;
 import java.text.Collator;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
-import javax.persistence.CascadeType;
-import javax.persistence.Entity;
-import javax.persistence.EntityManager;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
-import javax.persistence.Temporal;
-import javax.persistence.Transient;
+import jm.com.dpbennett.business.entity.BusinessEntity;
 import jm.com.dpbennett.business.entity.Person;
 import jm.com.dpbennett.business.entity.cm.Client;
 import jm.com.dpbennett.business.entity.hrm.Employee;
@@ -50,6 +50,21 @@ import jm.com.dpbennett.business.entity.util.ReturnMessage;
 public class Certification implements CertificationInterface {
 
     private static final long serialVersionUID = 1L;
+    private static final System.Logger LOG = System.getLogger(Certification.class.getName());
+    public static List<Certification> findAllByOwnerId(EntityManager em, Long ownerId) {
+        
+        try {
+            List<Certification> certifications = em.createQuery("SELECT c FROM Certification c"
+                    + " WHERE c.ownerId = " + ownerId
+                    + " ORDER BY c.ownerId DESC", Certification.class).getResultList();
+            
+            return certifications;
+            
+        } catch (Exception e) {
+            System.out.println(e);
+            return new ArrayList<>();
+        }
+    }
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
@@ -63,10 +78,8 @@ public class Certification implements CertificationInterface {
     private Employee certificateSignedBy;
     @OneToOne(cascade = CascadeType.REFRESH)
     private Business grantedTo;
-    @Temporal(javax.persistence.TemporalType.DATE)
-    private Date dateIssued;
-    @Temporal(javax.persistence.TemporalType.DATE)
-    private Date expiryDate;
+    private LocalDateTime dateIssued;
+    private LocalDateTime expiryDate;
     @OneToOne(cascade = CascadeType.REFRESH)
     private Client applicant;
     @Transient
@@ -75,6 +88,7 @@ public class Certification implements CertificationInterface {
     public Certification() {
     }
 
+    @SuppressWarnings("AccessingNonPublicFieldOfAnotherObject")
     public Certification(Certification certification) {
         this.number = certification.number;
         this.type = certification.type;
@@ -88,20 +102,6 @@ public class Certification implements CertificationInterface {
         this.applicant = certification.applicant;
     }
 
-    public static List<Certification> findAllByOwnerId(EntityManager em, Long ownerId) {
-
-        try {
-            List<Certification> certifications = em.createQuery("SELECT c FROM Certification c"
-                    + " WHERE c.ownerId = " + ownerId
-                    + " ORDER BY c.ownerId DESC", Certification.class).getResultList();
-
-            return certifications;
-
-        } catch (Exception e) {
-            System.out.println(e);
-            return new ArrayList<>();
-        }
-    }
 
     public Long getOwnerId() {
         return ownerId;
@@ -215,23 +215,23 @@ public class Certification implements CertificationInterface {
     }
 
     @Override
-    public Date getDateIssued() {
+    public LocalDateTime getDateIssued() {
         return dateIssued;
     }
 
     @Override
-    public void setDateIssued(Date dateIssued) {
+    public void setDateIssued(LocalDateTime dateIssued) {
         this.dateIssued = dateIssued;
     }
 
     @Override
-    public Date getExpiryDate() {
+    public LocalDateTime getExpiryDate() {
 
         return expiryDate;
     }
 
     @Override
-    public void setExpiryDate(Date expiryDate) {
+    public void setExpiryDate(LocalDateTime expiryDate) {
         this.expiryDate = expiryDate;
     }
 
@@ -260,10 +260,10 @@ public class Certification implements CertificationInterface {
 
     @Override
     public int compareTo(Object o) {
-        if ((((Certification) o).dateIssued != null) && (this.dateIssued != null)) {
+        if ((((Certification) o).id != null) && (this.id != null)) {
             return Collator.getInstance().compare(
-                    Long.toString(((Certification) o).dateIssued.getTime()),
-                    Long.toString(this.dateIssued.getTime()));
+                    Long.toString(((BusinessEntity) o).getId()),
+                    Long.toString(this.getId()));
         } else {
             return 0;
         }
@@ -329,16 +329,7 @@ public class Certification implements CertificationInterface {
         this.isDirty = isDirty;
     }
 
-    @Override
-    public Date getDateEntered() {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
-    }
-
-    @Override
-    public void setDateEntered(Date dateEntered) {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
-    }
-
+  
     @Override
     public ReturnMessage delete(EntityManager em) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
@@ -371,16 +362,6 @@ public class Certification implements CertificationInterface {
 
     @Override
     public void setEnteredBy(Person person) {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
-    }
-
-    @Override
-    public Date getDateEdited() {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
-    }
-
-    @Override
-    public void setDateEdited(Date dateEdited) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
@@ -426,6 +407,34 @@ public class Certification implements CertificationInterface {
 
     @Override
     public void setSetting(String setting, String settingValue, String type, String category) {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    public ReturnMessage save(Object em) {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    public ReturnMessage validate(Object em) {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public LocalDateTime getDateEntered() {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public void setDateEntered(LocalDateTime dateEntered) {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public LocalDateTime getDateEdited() {
+        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public void setDateEdited(LocalDateTime dateEdited) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 }

--- a/src/main/java/jm/com/dpbennett/business/entity/cert/CertificationInterface.java
+++ b/src/main/java/jm/com/dpbennett/business/entity/cert/CertificationInterface.java
@@ -20,9 +20,9 @@ Email: info@dpbennett.com.jm
 
 package jm.com.dpbennett.business.entity.cert;
 
+import jakarta.persistence.EntityManager;
 import java.io.Serializable;
-import java.util.Date;
-import javax.persistence.EntityManager;
+import java.time.LocalDateTime;
 import jm.com.dpbennett.business.entity.BusinessEntity;
 import jm.com.dpbennett.business.entity.cm.Client;
 import jm.com.dpbennett.business.entity.hrm.Business;
@@ -50,9 +50,9 @@ public interface CertificationInterface extends BusinessEntity, Comparable, Seri
 
     Employee getCertificateSignedBy();
 
-    Date getDateIssued();
+    LocalDateTime getDateIssued();
 
-    Date getExpiryDate();
+    LocalDateTime getExpiryDate();
 
     Business getGrantedTo();
 
@@ -88,9 +88,9 @@ public interface CertificationInterface extends BusinessEntity, Comparable, Seri
 
     void setCertificateSignedBy(Employee certificateSignedBy);
 
-    void setDateIssued(Date dateIssued);
+    void setDateIssued(LocalDateTime dateIssued);
 
-    void setExpiryDate(Date expiryDate);
+    void setExpiryDate(LocalDateTime expiryDate);
 
     void setGrantedTo(Business grantedTo);
 

--- a/src/main/java/jm/com/dpbennett/business/entity/cm/Client.java
+++ b/src/main/java/jm/com/dpbennett/business/entity/cm/Client.java
@@ -19,29 +19,28 @@ Email: info@dpbennett.com.jm
  */
 package jm.com.dpbennett.business.entity.cm;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import jm.com.dpbennett.business.entity.fm.Discount;
 import jm.com.dpbennett.business.entity.hrm.Address;
 import jm.com.dpbennett.business.entity.fm.AccPacCustomer;
 import java.text.Collator;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EntityManager;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.NamedQueries;
-import javax.persistence.NamedQuery;
-import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
-import javax.persistence.Temporal;
-import javax.persistence.Transient;
 import jm.com.dpbennett.business.entity.Person;
 import jm.com.dpbennett.business.entity.hrm.Contact;
 import jm.com.dpbennett.business.entity.hrm.Employee;
@@ -89,14 +88,10 @@ public class Client implements ClientInterface {
     private String notes;
     private Boolean internal;
     private Double creditLimit;
-    @Temporal(javax.persistence.TemporalType.DATE)
-    private Date dateFirstReceived;
-    @Temporal(javax.persistence.TemporalType.DATE)
-    private Date dateLastAccessed;
-    @Temporal(javax.persistence.TemporalType.DATE)
-    private Date dateEntered;
-    @Temporal(javax.persistence.TemporalType.DATE)
-    private Date dateEdited;
+    private LocalDateTime dateFirstReceived;
+    private LocalDateTime dateLastAccessed;
+    private LocalDateTime dateEntered;
+    private LocalDateTime dateEdited;
     private Boolean tag;
     private String taxRegistrationNumber;
     private Boolean active;
@@ -299,12 +294,7 @@ public class Client implements ClientInterface {
     }
 
     @Override
-    public Date getDateEdited() {
-        return dateEdited;
-    }
-
-    @Override
-    public void setDateEdited(Date dateEdited) {
+    public void setDateEdited(LocalDateTime dateEdited) {
         this.dateEdited = dateEdited;
     }
 
@@ -367,16 +357,6 @@ public class Client implements ClientInterface {
     @Override
     public void setInternational(Boolean international) {
         this.international = international;
-    }
-
-    @Override
-    public Date getDateEntered() {
-        return dateEntered;
-    }
-
-    @Override
-    public void setDateEntered(Date dateEntered) {
-        this.dateEntered = dateEntered;
     }
 
     @Override
@@ -635,12 +615,12 @@ public class Client implements ClientInterface {
     }
 
     @Override
-    public Date getDateLastAccessed() {
+    public LocalDateTime getDateLastAccessed() {
         return dateLastAccessed;
     }
 
     @Override
-    public void setDateLastAccessed(Date dateLastAccessed) {
+    public void setDateLastAccessed(LocalDateTime dateLastAccessed) {
         this.dateLastAccessed = dateLastAccessed;
     }
 
@@ -652,12 +632,12 @@ public class Client implements ClientInterface {
     }
 
     @Override
-    public Date getDateFirstReceived() {
+    public LocalDateTime getDateFirstReceived() {
         return dateFirstReceived;
     }
 
     @Override
-    public void setDateFirstReceived(Date dateFirstReceived) {
+    public void setDateFirstReceived(LocalDateTime dateFirstReceived) {
         this.dateFirstReceived = dateFirstReceived;
     }
 
@@ -974,6 +954,11 @@ public class Client implements ClientInterface {
         }
     }
 
+    /**
+     *
+     * @param em
+     * @return
+     */
     @Override
     public ReturnMessage save(EntityManager em) {
         try {
@@ -981,7 +966,7 @@ public class Client implements ClientInterface {
             if (enteredBy != null) {
                 enteredBy.save(em);
             }
-            
+
             if (editedBy != null) {
                 editedBy.save(em);
             }
@@ -989,23 +974,23 @@ public class Client implements ClientInterface {
             if (billingAddress != null) {
                 billingAddress.save(em);
             }
-            
+
             if (billingContact != null) {
                 billingContact.save(em);
             }
-            
+
             if (discount != null) {
                 discount.save(em);
             }
-            
+
             if (defaultTax != null) {
                 defaultTax.save(em);
             }
-            
+
             for (Contact contact : getContacts()) {
                 contact.save(em);
             }
-            
+
             for (Address address : getAddresses()) {
                 address.save(em);
             }
@@ -1122,4 +1107,20 @@ public class Client implements ClientInterface {
     public void setSetting(String setting, String settingValue, String type, String category) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
+
+    @Override
+    public void setDateEntered(LocalDateTime dateEntered) {
+        this.dateEntered = dateEntered;
+    }
+
+    @Override
+    public LocalDateTime getDateEdited() {
+        return dateEdited;
+    }
+
+    @Override
+    public LocalDateTime getDateEntered() {
+        return dateEntered;
+    }
+    
 }

--- a/src/main/java/jm/com/dpbennett/business/entity/cm/ClientInterface.java
+++ b/src/main/java/jm/com/dpbennett/business/entity/cm/ClientInterface.java
@@ -20,10 +20,11 @@ Email: info@dpbennett.com.jm
 
 package jm.com.dpbennett.business.entity.cm;
 
+import jakarta.persistence.EntityManager;
 import java.io.Serializable;
+import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.List;
-import javax.persistence.EntityManager;
 import jm.com.dpbennett.business.entity.BusinessEntity;
 import jm.com.dpbennett.business.entity.fm.AccPacCustomer;
 import jm.com.dpbennett.business.entity.fm.Discount;
@@ -72,16 +73,16 @@ public interface ClientInterface extends BusinessEntity, Comparable, Customer, S
     Double getCreditLimit();
 
     @Override
-    Date getDateEdited();
+    LocalDateTime getDateEdited();
 
     @Override
-    Date getDateEntered();
+    LocalDateTime getDateEntered();
 
     @Override
-    Date getDateFirstReceived();
+    LocalDateTime getDateFirstReceived();
 
     @Override
-    Date getDateLastAccessed();
+    LocalDateTime getDateLastAccessed();
 
     @Override
     Address getDefaultAddress();
@@ -170,16 +171,16 @@ public interface ClientInterface extends BusinessEntity, Comparable, Customer, S
     void setCreditLimit(Double creditLimit);
 
     @Override
-    void setDateEdited(Date dateEdited);
+    void setDateEdited(LocalDateTime dateEdited);
 
     @Override
-    void setDateEntered(Date dateEntered);
+    void setDateEntered(LocalDateTime dateEntered);
 
     @Override
-    void setDateFirstReceived(Date dateFirstReceived);
+    void setDateFirstReceived(LocalDateTime dateFirstReceived);
 
     @Override
-    void setDateLastAccessed(Date dateLastAccessed);
+    void setDateLastAccessed(LocalDateTime dateLastAccessed);
 
     void setDefaultTax(Tax defaultTax);
 

--- a/src/main/java/jm/com/dpbennett/business/entity/cm/Customer.java
+++ b/src/main/java/jm/com/dpbennett/business/entity/cm/Customer.java
@@ -20,8 +20,8 @@ Email: info@dpbennett.com.jm
 
 package jm.com.dpbennett.business.entity.cm;
 
+import java.time.LocalDateTime;
 import jm.com.dpbennett.business.entity.hrm.Address;
-import java.util.Date;
 import java.util.List;
 import jm.com.dpbennett.business.entity.hrm.Contact;
 
@@ -47,9 +47,9 @@ public interface Customer {
 
     public Contact getDefaultContact();
 
-    public Date getDateLastAccessed();
+    public LocalDateTime getDateLastAccessed();
 
-    public void setDateLastAccessed(Date dateLastAccessed);
+    public void setDateLastAccessed(LocalDateTime dateLastAccessed);
 
     public String getNumber();
 
@@ -59,9 +59,9 @@ public interface Customer {
 
     public void setType(String type);
 
-    public Date getDateFirstReceived();
+    public LocalDateTime getDateFirstReceived();
 
-    public void setDateFirstReceived(Date dateFirstReceived);
+    public void setDateFirstReceived(LocalDateTime dateFirstReceived);
 
     public String getNotes();
 

--- a/src/main/java/jm/com/dpbennett/business/entity/dm/Attachment.java
+++ b/src/main/java/jm/com/dpbennett/business/entity/dm/Attachment.java
@@ -19,25 +19,26 @@ Email: info@dpbennett.com.jm
  */
 package jm.com.dpbennett.business.entity.dm;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.io.Serializable;
 import java.text.Collator;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EntityManager;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.NamedQueries;
-import javax.persistence.NamedQuery;
-import javax.persistence.Table;
-import javax.persistence.Transient;
 import jm.com.dpbennett.business.entity.BusinessEntity;
 import jm.com.dpbennett.business.entity.Person;
 import jm.com.dpbennett.business.entity.sm.SystemOption;
@@ -393,12 +394,12 @@ public class Attachment implements BusinessEntity, Serializable, Comparable {
     }
 
     @Override
-    public Date getDateEntered() {
+    public LocalDateTime getDateEntered() {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public void setDateEntered(Date dateEntered) {
+    public void setDateEntered(LocalDateTime dateEntered) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
@@ -428,12 +429,12 @@ public class Attachment implements BusinessEntity, Serializable, Comparable {
     }
 
     @Override
-    public Date getDateEdited() {
+    public LocalDateTime getDateEdited() {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public void setDateEdited(Date dateEdited) {
+    public void setDateEdited(LocalDateTime dateEdited) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 

--- a/src/main/java/jm/com/dpbennett/business/entity/dm/DocumentSequenceNumber.java
+++ b/src/main/java/jm/com/dpbennett/business/entity/dm/DocumentSequenceNumber.java
@@ -20,18 +20,18 @@ Email: info@dpbennett.com.jm
 
 package jm.com.dpbennett.business.entity.dm;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import java.io.Serializable;
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
-import javax.persistence.Entity;
-import javax.persistence.EntityManager;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.NamedQueries;
-import javax.persistence.NamedQuery;
-import javax.persistence.Table;
-import javax.persistence.Transient;
 import jm.com.dpbennett.business.entity.BusinessEntity;
 import jm.com.dpbennett.business.entity.Person;
 import jm.com.dpbennett.business.entity.sm.SystemOption;
@@ -62,6 +62,78 @@ import jm.com.dpbennett.business.entity.util.ReturnMessage;
 public class DocumentSequenceNumber implements Serializable, BusinessEntity {
 
     private static final long serialVersionUID = 1L;
+    private static final System.Logger LOG = System.getLogger(DocumentSequenceNumber.class.getName());
+    public static List<DocumentSequenceNumber> findAllDocumentSequenceNumbers(EntityManager em) {
+        
+        try {
+            List<DocumentSequenceNumber> documentSequenceNumbers = em.createNamedQuery("findAllDocumentSequenceNumbers", DocumentSequenceNumber.class).getResultList();
+            
+            return documentSequenceNumbers;
+        } catch (Exception e) {
+            System.out.println(e);
+            return null;
+        }
+    }
+    public static Long findLastDocumentSequenceNumber(EntityManager em, Integer year, Integer month, Long typeId) {
+        Long last;
+        
+        try {
+            last = em.createNamedQuery("getLastDocumentSequenceNumber",
+                    Long.class).setParameter("yearReceived", year).
+                    setParameter("monthReceived", month).
+                    setParameter("documentTypeId", typeId).getSingleResult();
+        } catch (Exception e) {
+            System.out.println(e);
+            last = null;
+        }
+        
+        return last;
+    }
+    public static Long findDocumentSequenceNumber(EntityManager em,
+            Long sequentialNumber,
+            Integer year,
+            Integer month,
+            Long typeId) {
+        
+        Long last;
+        
+        try {
+            last = em.createNamedQuery("getDocumentSequenceNumber",
+                    Long.class).
+                    setParameter("yearReceived", year).
+                    setParameter("monthReceived", month).
+                    setParameter("documentTypeId", typeId).
+                    setParameter("sequentialNumber", sequentialNumber).getSingleResult();
+        } catch (Exception e) {
+            System.out.println(e);
+            last = null;
+        }
+        
+        return last;
+    }
+    public static Long findNextDocumentSequenceNumber(EntityManager em, Integer year, Integer month, Long typeId) {
+        Long last;
+        
+        DocumentSequenceNumber documentSequenceNumber = new DocumentSequenceNumber();
+        
+        last = DocumentSequenceNumber.findLastDocumentSequenceNumber(em, year, month, typeId);
+        
+        if (last == null) {
+            documentSequenceNumber.setYearReceived(year);
+            documentSequenceNumber.setMonthReceived(month);
+            documentSequenceNumber.setDocumentTypeId(typeId);
+            documentSequenceNumber.setSequentialNumber(0L);
+            em.persist(documentSequenceNumber);
+        } else {
+            documentSequenceNumber.setYearReceived(year);
+            documentSequenceNumber.setMonthReceived(month);
+            documentSequenceNumber.setDocumentTypeId(typeId);
+            documentSequenceNumber.setSequentialNumber(last + 1);
+            em.persist(documentSequenceNumber);
+        }
+        
+        return documentSequenceNumber.getSequentialNumber();
+    }
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
@@ -160,80 +232,6 @@ public class DocumentSequenceNumber implements Serializable, BusinessEntity {
 
     }
 
-    public static List<DocumentSequenceNumber> findAllDocumentSequenceNumbers(EntityManager em) {
-
-        try {
-            List<DocumentSequenceNumber> documentSequenceNumbers = em.createNamedQuery("findAllDocumentSequenceNumbers", DocumentSequenceNumber.class).getResultList();
-
-            return documentSequenceNumbers;
-        } catch (Exception e) {
-            System.out.println(e);
-            return null;
-        }
-    }
-
-    public static Long findLastDocumentSequenceNumber(EntityManager em, Integer year, Integer month, Long typeId) {
-        Long last;
-
-        try {
-            last = em.createNamedQuery("getLastDocumentSequenceNumber",
-                    Long.class).setParameter("yearReceived", year).
-                    setParameter("monthReceived", month).
-                    setParameter("documentTypeId", typeId).getSingleResult();
-        } catch (Exception e) {
-            System.out.println(e);
-            last = null;
-        }
-
-        return last;
-    }
-
-    public static Long findDocumentSequenceNumber(EntityManager em,
-            Long sequentialNumber,
-            Integer year,
-            Integer month,
-            Long typeId) {
-
-        Long last;
-
-        try {
-            last = em.createNamedQuery("getDocumentSequenceNumber",
-                    Long.class).
-                    setParameter("yearReceived", year).
-                    setParameter("monthReceived", month).
-                    setParameter("documentTypeId", typeId).
-                    setParameter("sequentialNumber", sequentialNumber).getSingleResult();
-        } catch (Exception e) {
-            System.out.println(e);
-            last = null;
-        }
-
-        return last;
-    }
-
-    public static Long findNextDocumentSequenceNumber(EntityManager em, Integer year, Integer month, Long typeId) {
-        Long last;
-
-        DocumentSequenceNumber documentSequenceNumber = new DocumentSequenceNumber();
-
-        last = DocumentSequenceNumber.findLastDocumentSequenceNumber(em, year, month, typeId);
-
-        if (last == null) {
-            documentSequenceNumber.setYearReceived(year);
-            documentSequenceNumber.setMonthReceived(month);
-            documentSequenceNumber.setDocumentTypeId(typeId);
-            documentSequenceNumber.setSequentialNumber(0L);
-            em.persist(documentSequenceNumber);
-        } else {
-            documentSequenceNumber.setYearReceived(year);
-            documentSequenceNumber.setMonthReceived(month);
-            documentSequenceNumber.setDocumentTypeId(typeId);
-            documentSequenceNumber.setSequentialNumber(last + 1);
-            em.persist(documentSequenceNumber);
-        }
-
-        return documentSequenceNumber.getSequentialNumber();
-    }
 
     @Override
     public ReturnMessage save(EntityManager em) {
@@ -266,12 +264,12 @@ public class DocumentSequenceNumber implements Serializable, BusinessEntity {
     }
 
     @Override
-    public Date getDateEntered() {
+    public LocalDateTime getDateEntered() {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public void setDateEntered(Date dateEntered) {
+    public void setDateEntered(LocalDateTime dateEntered) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
@@ -311,12 +309,12 @@ public class DocumentSequenceNumber implements Serializable, BusinessEntity {
     }
 
     @Override
-    public Date getDateEdited() {
+    public LocalDateTime getDateEdited() {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public void setDateEdited(Date dateEdited) {
+    public void setDateEdited(LocalDateTime dateEdited) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 

--- a/src/main/java/jm/com/dpbennett/business/entity/dm/DocumentStandard.java
+++ b/src/main/java/jm/com/dpbennett/business/entity/dm/DocumentStandard.java
@@ -19,25 +19,25 @@ Email: info@dpbennett.com.jm
  */
 package jm.com.dpbennett.business.entity.dm;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.Transient;
 import jm.com.dpbennett.business.entity.hrm.Employee;
 import jm.com.dpbennett.business.entity.fm.Classification;
 import java.text.Collator;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EntityManager;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.NamedQueries;
-import javax.persistence.NamedQuery;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
-import javax.persistence.Temporal;
-import javax.persistence.Transient;
 import jm.com.dpbennett.business.entity.BusinessEntity;
 import jm.com.dpbennett.business.entity.Person;
 import jm.com.dpbennett.business.entity.sm.SystemOption;
@@ -65,18 +65,12 @@ public class DocumentStandard implements Document, Comparable, BusinessEntity {
     private String number;
     private String enforcement;
     private Boolean autoGenerateNumber;
-    @Temporal(javax.persistence.TemporalType.DATE)
-    private Date dateRevised;
-    @Temporal(javax.persistence.TemporalType.DATE)
-    private Date dateConfirmed;
-    @Temporal(javax.persistence.TemporalType.DATE)
-    private Date datePublished;
-    @Temporal(javax.persistence.TemporalType.DATE)
-    private Date dateRevisionDue;
-    @Temporal(javax.persistence.TemporalType.DATE)
-    private Date dateEntered;
-    @Temporal(javax.persistence.TemporalType.DATE)
-    private Date dateEdited;
+    private LocalDateTime dateRevised;
+    private LocalDateTime dateConfirmed;
+    private LocalDateTime datePublished;
+    private LocalDateTime dateRevisionDue;
+    private LocalDateTime dateEntered;
+    private LocalDateTime dateEdited;
     private String url;
     @OneToOne(cascade = CascadeType.REFRESH)
     private Classification classification;
@@ -142,22 +136,22 @@ public class DocumentStandard implements Document, Comparable, BusinessEntity {
     }
 
     @Override
-    public Date getDateEntered() {
+    public LocalDateTime getDateEntered() {
         return dateEntered;
     }
 
     @Override
-    public void setDateEntered(Date dateEntered) {
+    public void setDateEntered(LocalDateTime dateEntered) {
         this.dateEntered = dateEntered;
     }
 
     @Override
-    public Date getDateEdited() {
+    public LocalDateTime getDateEdited() {
         return dateEdited;
     }
 
     @Override
-    public void setDateEdited(Date dateEdited) {
+    public void setDateEdited(LocalDateTime dateEdited) {
         this.dateEdited = dateEdited;
     }
 
@@ -347,35 +341,35 @@ public class DocumentStandard implements Document, Comparable, BusinessEntity {
         this.enforcement = enforcement;
     }
 
-    public Date getDateRevised() {
+    public LocalDateTime getDateRevised() {
         return dateRevised;
     }
 
-    public void setDateRevised(Date dateRevised) {
+    public void setDateRevised(LocalDateTime dateRevised) {
         this.dateRevised = dateRevised;
     }
 
-    public Date getDateConfirmed() {
+    public LocalDateTime getDateConfirmed() {
         return dateConfirmed;
     }
 
-    public void setDateConfirmed(Date dateConfirmed) {
+    public void setDateConfirmed(LocalDateTime dateConfirmed) {
         this.dateConfirmed = dateConfirmed;
     }
 
-    public Date getDatePublished() {
+    public LocalDateTime getDatePublished() {
         return datePublished;
     }
 
-    public void setDatePublished(Date datePublished) {
+    public void setDatePublished(LocalDateTime datePublished) {
         this.datePublished = datePublished;
     }
 
-    public Date getDateRevisionDue() {
+    public LocalDateTime getDateRevisionDue() {
         return dateRevisionDue;
     }
 
-    public void setDateRevisionDue(Date dateRevisionDue) {
+    public void setDateRevisionDue(LocalDateTime dateRevisionDue) {
         this.dateRevisionDue = dateRevisionDue;
     }
 
@@ -466,8 +460,8 @@ public class DocumentStandard implements Document, Comparable, BusinessEntity {
             String dateSearchField,
             String searchType,
             String originalSearchText,
-            Date startDate,
-            Date endDate) {
+            LocalDateTime startDate,
+            LocalDateTime endDate) {
 
         List<DocumentStandard> foundDocuments;
         String searchQuery = null;

--- a/src/main/java/jm/com/dpbennett/business/entity/dm/DocumentTracking.java
+++ b/src/main/java/jm/com/dpbennett/business/entity/dm/DocumentTracking.java
@@ -19,6 +19,18 @@ Email: info@dpbennett.com.jm
  */
 package jm.com.dpbennett.business.entity.dm;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import jm.com.dpbennett.business.entity.hrm.Employee;
 import jm.com.dpbennett.business.entity.hrm.Department;
 import jm.com.dpbennett.business.entity.cm.Client;
@@ -27,23 +39,10 @@ import java.io.Serializable;
 import java.text.Collator;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EntityManager;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.NamedQueries;
-import javax.persistence.NamedQuery;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
-import javax.persistence.Temporal;
-import javax.persistence.Transient;
 import jm.com.dpbennett.business.entity.BusinessEntity;
 import jm.com.dpbennett.business.entity.Person;
 import jm.com.dpbennett.business.entity.sm.SystemOption;
@@ -62,6 +61,163 @@ import jm.com.dpbennett.business.entity.util.ReturnMessage;
 public class DocumentTracking implements Document, Serializable, Comparable, BusinessEntity {
 
     private static final long serialVersionUID = 1L;
+    private static final System.Logger LOG = System.getLogger(DocumentTracking.class.getName());
+    public static List<DocumentTracking> findGroupedDocumentTrackingsByDateSearchField(
+            EntityManager em,
+            String dateSearchField,
+            String searchType,
+            Date startDate,
+            Date endDate) {
+        
+        List<DocumentTracking> foundDocuments;
+        String searchQuery = null;
+        
+        switch (searchType) {
+            case "General":
+                searchQuery
+                        = "SELECT new jm.com.dpbennett.entity.DocumentTracking(doc.type, COUNT(doc.type)) FROM DocumentTracking doc"
+                        + " WHERE (doc." + dateSearchField + " >= " + BusinessEntityUtils.getDateString(startDate, "'", "YMD", "-")
+                        + " AND doc." + dateSearchField + " <= " + BusinessEntityUtils.getDateString(endDate, "'", "YMD", "-") + ")"
+                        + " GROUP BY doc.type";
+                break;
+            case "My documents":
+                break;
+            case "My department's documents":
+                break;
+            default:
+                break;
+        }
+        
+        try {
+            foundDocuments = em.createQuery(searchQuery, DocumentTracking.class).getResultList();
+            if (foundDocuments == null) {
+                foundDocuments = new ArrayList<>();
+            }
+        } catch (Exception e) {
+            System.out.println(e);
+            return null;
+        }
+        
+        return foundDocuments;
+    }
+    public static List<DocumentTracking> findDocumentTrackingsByDateSearchField(
+            EntityManager em,
+            String dateSearchField,
+            String searchType,
+            String originalSearchText,
+            Date startDate,
+            Date endDate) {
+        
+        List<DocumentTracking> foundDocuments;
+        String searchQuery = null;
+        String searchTextAndClause = "";
+        String searchText = originalSearchText;
+        
+        switch (searchType) {
+            case "General":
+                if (!searchText.equals("")) {
+                    searchTextAndClause
+                            = " AND ("
+                            + " UPPER(doc.number) LIKE '%" + searchText.toUpperCase() + "%'"
+                            + " OR UPPER(responsibleDepartment.name) LIKE '%" + searchText.toUpperCase() + "%'"
+                            + " OR UPPER(responsibleOfficer.firstName) LIKE '%" + searchText.toUpperCase() + "%'"
+                            + " OR UPPER(responsibleOfficer.lastName) LIKE '%" + searchText.toUpperCase() + "%'"
+                            + " OR UPPER(submittedBy.firstName) LIKE '%" + searchText.toUpperCase() + "%'"
+                            + " OR UPPER(submittedBy.lastName) LIKE '%" + searchText.toUpperCase() + "%'"
+                            + " OR UPPER(doc.description) LIKE '%" + searchText.toUpperCase() + "%'"
+                            + " OR UPPER(doc.comments) LIKE '%" + searchText.toUpperCase() + "%'"
+                            + " OR UPPER(doc.notes) LIKE '%" + searchText.toUpperCase() + "%'"
+                            + " OR UPPER(doc.status) LIKE '%" + searchText.toUpperCase() + "%'"
+                            + " OR UPPER(doc.priorityLevel) LIKE '%" + searchText.toUpperCase() + "%'"
+                            + " OR UPPER(doc.url) LIKE '%" + searchText.toUpperCase() + "%'"
+                            + " OR UPPER(classification.name) LIKE '%" + searchText.toUpperCase() + "%'"
+                            + " OR UPPER(doc.workPerformedOnDocument) LIKE '%" + searchText.toUpperCase() + "%'"
+                            + " OR UPPER(doc.documentForm) LIKE '%" + searchText.toUpperCase() + "%'"
+                            + " )";
+                }
+                searchQuery
+                        = "SELECT doc FROM DocumentTracking doc"
+                        + " JOIN doc.responsibleDepartment responsibleDepartment"
+                        + " JOIN doc.responsibleOfficer responsibleOfficer"
+                        + " JOIN doc.submittedBy submittedBy"
+                        + " JOIN doc.classification classification"
+                        + " WHERE (doc." + dateSearchField + " >= " + BusinessEntityUtils.getDateString(startDate, "'", "YMD", "-")
+                        + " AND doc." + dateSearchField + " <= " + BusinessEntityUtils.getDateString(endDate, "'", "YMD", "-") + ")"
+                        + searchTextAndClause
+                        + " ORDER BY doc.dateReceived DESC";
+                break;
+            case "By type":
+                searchTextAndClause
+                        = " AND ("
+                        + " UPPER(t.name) = '" + searchText.toUpperCase() + "'"
+                        + " )";
+                searchQuery
+                        = "SELECT doc FROM DocumentTracking doc"
+                        + " JOIN doc.type t"
+                        + " WHERE (doc." + dateSearchField + " >= " + BusinessEntityUtils.getDateString(startDate, "'", "YMD", "-")
+                        + " AND doc." + dateSearchField + " <= " + BusinessEntityUtils.getDateString(endDate, "'", "YMD", "-") + ")"
+                        + searchTextAndClause
+                        + " ORDER BY doc.dateReceived DESC";
+                break;
+            case "My department's documents":
+                break;
+            default:
+                break;
+        }
+        
+        try {
+            foundDocuments = em.createQuery(searchQuery, DocumentTracking.class).getResultList();
+            if (foundDocuments == null) {
+                foundDocuments = new ArrayList<>();
+            }
+        } catch (Exception e) {
+            System.out.println(e);
+            return null;
+        }
+        
+        return foundDocuments;
+    }
+    public static DocumentTracking findDocumentTrackingById(EntityManager em, Long Id) {
+        
+        return em.find(DocumentTracking.class, Id);
+    }
+    public static List<DocumentTracking> findAllDocumentTrackings(EntityManager em) {
+        
+        try {
+            return em.createNamedQuery("findAllDocumentTrackings", DocumentTracking.class).getResultList();
+        } catch (Exception e) {
+            System.out.println(e);
+            return null;
+        }
+    }
+    public static String getDocumentTrackingNumber(DocumentTracking documentTracking, String prefix) {
+        String number = prefix;
+        
+        if (documentTracking.getResponsibleDepartment().getCode() != null) {
+            number = number + documentTracking.getResponsibleDepartment().getCode();
+        } else {
+            number = number + "?";
+        }
+        if (documentTracking.getDocumentType() != null) {
+            number = number + "_" + documentTracking.getDocumentType().getCode();
+        }
+        if (documentTracking.getDocumentForm() != null) {
+            number = number + "/" + documentTracking.getDocumentForm();
+        }
+        if (documentTracking.getSequenceNumber() != null) {
+            NumberFormat formatter = DecimalFormat.getIntegerInstance();
+            formatter.setMinimumIntegerDigits(2);
+            number = number + "_" + formatter.format(documentTracking.getSequenceNumber());
+        } else {
+            number = number + "_?";
+        }
+        if (documentTracking.getDateReceived() != null) {
+            number = number + "/" + BusinessEntityUtils.getMonthShortFormat(documentTracking.getDateReceived())
+                    + BusinessEntityUtils.getYearShortFormat(documentTracking.getDateReceived(), 2);
+        }
+        
+        return number;
+    }
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
@@ -69,8 +225,7 @@ public class DocumentTracking implements Document, Serializable, Comparable, Bus
     private DocumentType documentType;
     private String number;
     private Boolean autoGenerateNumber;
-    @Temporal(javax.persistence.TemporalType.DATE)
-    private Date dateReceived;
+    private LocalDateTime dateReceived;
     @OneToOne(cascade = CascadeType.REFRESH)
     private Department requestingDepartment;
     @OneToOne(cascade = CascadeType.REFRESH)
@@ -83,10 +238,8 @@ public class DocumentTracking implements Document, Serializable, Comparable, Bus
     private String description;
     @Column(length = 1024)
     private String notes;
-    @Temporal(javax.persistence.TemporalType.DATE)
-    private Date expectedDateOfCompletion;
-    @Temporal(javax.persistence.TemporalType.DATE)
-    private Date dateOfCompletion;
+    private LocalDateTime expectedDateOfCompletion;
+    private LocalDateTime dateOfCompletion;
     private String url;
     @OneToOne(cascade = CascadeType.REFRESH)
     private Classification classification;
@@ -112,6 +265,10 @@ public class DocumentTracking implements Document, Serializable, Comparable, Bus
     private Boolean isDirty;
 
     public DocumentTracking() {
+    }
+    public DocumentTracking(DocumentType documentType, Long numberOfDocuments) {
+        this.documentType = documentType;
+        this.numberOfDocuments = numberOfDocuments;
     }
 
     @Override
@@ -167,11 +324,8 @@ public class DocumentTracking implements Document, Serializable, Comparable, Bus
     }
 
     public Integer getYearReceived() {
-        Calendar c = Calendar.getInstance();
-
         if (dateReceived != null) {
-            c.setTime(dateReceived);
-            yearReceived = c.get(Calendar.YEAR);
+            yearReceived = dateReceived.getYear();
         }
         return yearReceived;
     }
@@ -192,10 +346,6 @@ public class DocumentTracking implements Document, Serializable, Comparable, Bus
         this.externalClient = externalClient;
     }
 
-    public DocumentTracking(DocumentType documentType, Long numberOfDocuments) {
-        this.documentType = documentType;
-        this.numberOfDocuments = numberOfDocuments;
-    }
 
     public Long getNumberOfDocuments() {
         return numberOfDocuments;
@@ -237,11 +387,8 @@ public class DocumentTracking implements Document, Serializable, Comparable, Bus
     }
 
     public Integer getMonthReceived() {
-        Calendar c = Calendar.getInstance();
-
         if (dateReceived != null) {
-            c.setTime(dateReceived);
-            monthReceived = c.get(Calendar.MONTH);
+            monthReceived = dateReceived.getMonthValue() - 1;
         }
         return monthReceived;
     }
@@ -306,19 +453,19 @@ public class DocumentTracking implements Document, Serializable, Comparable, Bus
         this.id = id;
     }
 
-    public Date getDateOfCompletion() {
+    public LocalDateTime getDateOfCompletion() {
         return dateOfCompletion;
     }
 
-    public void setDateOfCompletion(Date dateOfCompletion) {
+    public void setDateOfCompletion(LocalDateTime dateOfCompletion) {
         this.dateOfCompletion = dateOfCompletion;
     }
 
-    public Date getDateReceived() {
+    public LocalDateTime getDateReceived() {
         return dateReceived;
     }
 
-    public void setDateReceived(Date dateReceived) {
+    public void setDateReceived(LocalDateTime dateReceived) {
         this.dateReceived = dateReceived;
     }
 
@@ -327,11 +474,11 @@ public class DocumentTracking implements Document, Serializable, Comparable, Bus
         return description;
     }
 
-    public Date getExpectedDateOfCompletion() {
+    public LocalDateTime getExpectedDateOfCompletion() {
         return expectedDateOfCompletion;
     }
 
-    public void setExpectedDateOfCompletion(Date expectedDateOfCompletion) {
+    public void setExpectedDateOfCompletion(LocalDateTime expectedDateOfCompletion) {
         this.expectedDateOfCompletion = expectedDateOfCompletion;
     }
 
@@ -454,203 +601,43 @@ public class DocumentTracking implements Document, Serializable, Comparable, Bus
 
     }
 
-    public static List<DocumentTracking> findGroupedDocumentTrackingsByDateSearchField(
-            EntityManager em,
-            String dateSearchField,
-            String searchType,
-            Date startDate,
-            Date endDate) {
-
-        List<DocumentTracking> foundDocuments;
-        String searchQuery = null;
-
-        switch (searchType) {
-            case "General":
-                searchQuery
-                        = "SELECT new jm.com.dpbennett.entity.DocumentTracking(doc.type, COUNT(doc.type)) FROM DocumentTracking doc"
-                        + " WHERE (doc." + dateSearchField + " >= " + BusinessEntityUtils.getDateString(startDate, "'", "YMD", "-")
-                        + " AND doc." + dateSearchField + " <= " + BusinessEntityUtils.getDateString(endDate, "'", "YMD", "-") + ")"
-                        + " GROUP BY doc.type";
-                break;
-            case "My documents":
-                break;
-            case "My department's documents":
-                break;
-            default:
-                break;
-        }
-
-        try {
-            foundDocuments = em.createQuery(searchQuery, DocumentTracking.class).getResultList();
-            if (foundDocuments == null) {
-                foundDocuments = new ArrayList<>();
-            }
-        } catch (Exception e) {
-            System.out.println(e);
-            return null;
-        }
-
-        return foundDocuments;
-    }
-
-    public static List<DocumentTracking> findDocumentTrackingsByDateSearchField(
-            EntityManager em,
-            String dateSearchField,
-            String searchType,
-            String originalSearchText,
-            Date startDate,
-            Date endDate) {
-
-        List<DocumentTracking> foundDocuments;
-        String searchQuery = null;
-        String searchTextAndClause = "";
-        String searchText = originalSearchText;
-
-        switch (searchType) {
-            case "General":
-                if (!searchText.equals("")) {
-                    searchTextAndClause
-                            = " AND ("
-                            + " UPPER(doc.number) LIKE '%" + searchText.toUpperCase() + "%'"
-                            + " OR UPPER(responsibleDepartment.name) LIKE '%" + searchText.toUpperCase() + "%'"
-                            + " OR UPPER(responsibleOfficer.firstName) LIKE '%" + searchText.toUpperCase() + "%'"
-                            + " OR UPPER(responsibleOfficer.lastName) LIKE '%" + searchText.toUpperCase() + "%'"
-                            + " OR UPPER(submittedBy.firstName) LIKE '%" + searchText.toUpperCase() + "%'"
-                            + " OR UPPER(submittedBy.lastName) LIKE '%" + searchText.toUpperCase() + "%'"
-                            + " OR UPPER(doc.description) LIKE '%" + searchText.toUpperCase() + "%'"
-                            + " OR UPPER(doc.comments) LIKE '%" + searchText.toUpperCase() + "%'"
-                            + " OR UPPER(doc.notes) LIKE '%" + searchText.toUpperCase() + "%'"
-                            + " OR UPPER(doc.status) LIKE '%" + searchText.toUpperCase() + "%'"
-                            + " OR UPPER(doc.priorityLevel) LIKE '%" + searchText.toUpperCase() + "%'"
-                            + " OR UPPER(doc.url) LIKE '%" + searchText.toUpperCase() + "%'"
-                            + " OR UPPER(classification.name) LIKE '%" + searchText.toUpperCase() + "%'"
-                            + " OR UPPER(doc.workPerformedOnDocument) LIKE '%" + searchText.toUpperCase() + "%'"
-                            + " OR UPPER(doc.documentForm) LIKE '%" + searchText.toUpperCase() + "%'"
-                            + " )";
-                }
-                searchQuery
-                        = "SELECT doc FROM DocumentTracking doc"
-                        + " JOIN doc.responsibleDepartment responsibleDepartment"
-                        + " JOIN doc.responsibleOfficer responsibleOfficer"
-                        + " JOIN doc.submittedBy submittedBy"
-                        + " JOIN doc.classification classification"
-                        + " WHERE (doc." + dateSearchField + " >= " + BusinessEntityUtils.getDateString(startDate, "'", "YMD", "-")
-                        + " AND doc." + dateSearchField + " <= " + BusinessEntityUtils.getDateString(endDate, "'", "YMD", "-") + ")"
-                        + searchTextAndClause
-                        + " ORDER BY doc.dateReceived DESC";
-                break;
-            case "By type":
-                searchTextAndClause
-                        = " AND ("
-                        + " UPPER(t.name) = '" + searchText.toUpperCase() + "'"
-                        + " )";
-                searchQuery
-                        = "SELECT doc FROM DocumentTracking doc"
-                        + " JOIN doc.type t"
-                        + " WHERE (doc." + dateSearchField + " >= " + BusinessEntityUtils.getDateString(startDate, "'", "YMD", "-")
-                        + " AND doc." + dateSearchField + " <= " + BusinessEntityUtils.getDateString(endDate, "'", "YMD", "-") + ")"
-                        + searchTextAndClause
-                        + " ORDER BY doc.dateReceived DESC";
-                break;
-            case "My department's documents":
-                break;
-            default:
-                break;
-        }
-
-        try {
-            foundDocuments = em.createQuery(searchQuery, DocumentTracking.class).getResultList();
-            if (foundDocuments == null) {
-                foundDocuments = new ArrayList<>();
-            }
-        } catch (Exception e) {
-            System.out.println(e);
-            return null;
-        }
-
-        return foundDocuments;
-    }
-
-    public static DocumentTracking findDocumentTrackingById(EntityManager em, Long Id) {
-
-        return em.find(DocumentTracking.class, Id);
-    }
-
-    public static List<DocumentTracking> findAllDocumentTrackings(EntityManager em) {
-
-        try {
-            return em.createNamedQuery("findAllDocumentTrackings", DocumentTracking.class).getResultList();
-        } catch (Exception e) {
-            System.out.println(e);
-            return null;
-        }
-    }
-
-    public static String getDocumentTrackingNumber(DocumentTracking documentTracking, String prefix) {
-        String number = prefix;
-
-        if (documentTracking.getResponsibleDepartment().getCode() != null) {
-            number = number + documentTracking.getResponsibleDepartment().getCode();
-        } else {
-            number = number + "?";
-        }
-        if (documentTracking.getDocumentType() != null) {
-            number = number + "_" + documentTracking.getDocumentType().getCode();
-        }
-        if (documentTracking.getDocumentForm() != null) {
-            number = number + "/" + documentTracking.getDocumentForm();
-        }
-        if (documentTracking.getSequenceNumber() != null) {
-            NumberFormat formatter = DecimalFormat.getIntegerInstance();
-            formatter.setMinimumIntegerDigits(2);
-            number = number + "_" + formatter.format(documentTracking.getSequenceNumber());
-        } else {
-            number = number + "_?";
-        }
-        if (documentTracking.getDateReceived() != null) {
-            number = number + "/" + BusinessEntityUtils.getMonthShortFormat(documentTracking.getDateReceived())
-                    + BusinessEntityUtils.getYearShortFormat(documentTracking.getDateReceived(), 2);
-        }
-
-        return number;
-    }
 
     @Override
     public ReturnMessage save(EntityManager em) {
         try {
-            
+
             if (documentType != null) {
                 documentType.save(em);
             }
-            
+
             if (requestingDepartment != null) {
                 requestingDepartment.save(em);
             }
-            
+
             if (responsibleDepartment != null) {
                 responsibleDepartment.save(em);
             }
-            
+
             if (responsibleOfficer != null) {
                 responsibleOfficer.save(em);
             }
-            
+
             if (submittedBy != null) {
                 submittedBy.save(em);
             }
-            
+
             if (classification != null) {
                 classification.save(em);
             }
-            
+
             if (externalClient.getId() != null) {
                 externalClient.save(em);
             }
-            
+
             if (editedBy != null) {
                 editedBy.save(em);
             }
-            
+
             em.getTransaction().begin();
             BusinessEntityUtils.saveBusinessEntity(em, this);
             em.getTransaction().commit();
@@ -699,22 +686,22 @@ public class DocumentTracking implements Document, Serializable, Comparable, Bus
     }
 
     @Override
-    public Date getDateEntered() {
+    public LocalDateTime getDateEntered() {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public void setDateEntered(Date dateEntered) {
+    public void setDateEntered(LocalDateTime dateEntered) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public Date getDateEdited() {
+    public LocalDateTime getDateEdited() {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public void setDateEdited(Date dateEdited) {
+    public void setDateEdited(LocalDateTime dateEdited) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 

--- a/src/main/java/jm/com/dpbennett/business/entity/dm/DocumentType.java
+++ b/src/main/java/jm/com/dpbennett/business/entity/dm/DocumentType.java
@@ -19,19 +19,19 @@ Email: info@dpbennett.com.jm
  */
 package jm.com.dpbennett.business.entity.dm;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import java.io.Serializable;
 import java.text.Collator;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EntityManager;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Table;
-import javax.persistence.Transient;
 import jm.com.dpbennett.business.entity.BusinessEntity;
 import jm.com.dpbennett.business.entity.Person;
 import jm.com.dpbennett.business.entity.sm.SystemOption;
@@ -333,22 +333,22 @@ public class DocumentType implements Comparable, BusinessEntity, Serializable {
     }
 
     @Override
-    public Date getDateEntered() {
+    public LocalDateTime getDateEntered() {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public void setDateEntered(Date dateEntered) {
+    public void setDateEntered(LocalDateTime dateEntered) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public Date getDateEdited() {
+    public LocalDateTime getDateEdited() {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public void setDateEdited(Date dateEdited) {
+    public void setDateEdited(LocalDateTime dateEdited) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 

--- a/src/main/java/jm/com/dpbennett/business/entity/dm/Post.java
+++ b/src/main/java/jm/com/dpbennett/business/entity/dm/Post.java
@@ -19,25 +19,25 @@ Email: info@dpbennett.com.jm
  */
 package jm.com.dpbennett.business.entity.dm;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import jm.com.dpbennett.business.entity.hrm.Employee;
 import jm.com.dpbennett.business.entity.fm.Classification;
 import java.text.Collator;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EntityManager;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.NamedQueries;
-import javax.persistence.NamedQuery;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
-import javax.persistence.Temporal;
-import javax.persistence.Transient;
 import jm.com.dpbennett.business.entity.BusinessEntity;
 import jm.com.dpbennett.business.entity.Person;
 import jm.com.dpbennett.business.entity.sm.SystemOption;
@@ -56,6 +56,202 @@ import jm.com.dpbennett.business.entity.util.ReturnMessage;
 public class Post implements Document, Comparable, BusinessEntity {
 
     private static final long serialVersionUID = 1L;
+    private static final System.Logger LOG = System.getLogger(Post.class.getName());
+    public static Post findActiveByName(EntityManager em, String value,
+            Boolean ignoreCase) {
+        
+        List<Post> posts;
+        
+        try {
+            
+            if (ignoreCase) {
+                posts = em.createQuery("SELECT p FROM Post p "
+                        + "WHERE UPPER(p.name) "
+                        + "= '" + value.toUpperCase() + "'"
+                                + " AND p.active = 1", Post.class).getResultList();
+            } else {
+                posts = em.createQuery("SELECT p FROM Post p "
+                        + "WHERE p.name "
+                        + "= '" + value + "'"
+                                + " AND p.active = 1", Post.class).getResultList();
+            }
+            
+            if (!posts.isEmpty()) {
+                return posts.get(0);
+            }
+            return null;
+        } catch (Exception e) {
+            System.out.println(e);
+            return null;
+        }
+    }
+    public static Post findByName(EntityManager em, String value,
+            Boolean ignoreCase) {
+        
+        List<Post> posts;
+        
+        try {
+            
+            if (ignoreCase) {
+                posts = em.createQuery("SELECT p FROM Post p "
+                        + "WHERE UPPER(p.name) "
+                        + "= '" + value.toUpperCase() + "'",
+                        Post.class).getResultList();
+            } else {
+                posts = em.createQuery("SELECT p FROM Post p "
+                        + "WHERE p.name "
+                        + "= '" + value + "'",
+                        Post.class).getResultList();
+            }
+            
+            if (!posts.isEmpty()) {
+                return posts.get(0);
+            }
+            return null;
+        } catch (Exception e) {
+            System.out.println(e);
+            return null;
+        }
+    }
+    public static List<Post> findByDateSearchField(
+            EntityManager em,
+            String dateSearchField,
+            String searchType,
+            String originalSearchText,
+            Date startDate,
+            Date endDate) {
+        
+        List<Post> foundPosts;
+        String searchQuery = null;
+        String searchTextAndClause = "";
+        String searchText = originalSearchText;
+        switch (searchType) {
+            case "General":
+                if (!searchText.equals("")) {
+                    searchTextAndClause
+                            = " AND ("
+                            + " UPPER(post.number) LIKE '%" + searchText.toUpperCase() + "%'"
+                            + " OR UPPER(post.comments) LIKE '%" + searchText.toUpperCase() + "%'"
+                            + " OR UPPER(post.notes) LIKE '%" + searchText.toUpperCase() + "%'"
+                            + " OR UPPER(post.url) LIKE '%" + searchText.toUpperCase() + "%'"
+                            + " OR UPPER(classification.name) LIKE '%" + searchText.toUpperCase() + "%'"
+                            + " OR UPPER(post.documentForm) LIKE '%" + searchText.toUpperCase() + "%'"
+                            + " )";
+                }
+                searchQuery
+                        = "SELECT post FROM Post post"
+                        + " JOIN post.classification classification"
+                        + " WHERE (post." + dateSearchField + " >= " + BusinessEntityUtils.getDateString(startDate, "'", "YMD", "-")
+                        + " AND post." + dateSearchField + " <= " + BusinessEntityUtils.getDateString(endDate, "'", "YMD", "-") + ")"
+                        + searchTextAndClause
+                        + " ORDER BY post." + dateSearchField + " DESC";
+                break;
+            case "By type":
+                searchTextAndClause
+                        = " AND ("
+                        + " UPPER(t.name) = '" + searchText.toUpperCase() + "'"
+                        + " )";
+                searchQuery
+                        = "SELECT post FROM Post post"
+                        + " JOIN post.documentType t"
+                        + " WHERE (post." + dateSearchField + " >= " + BusinessEntityUtils.getDateString(startDate, "'", "YMD", "-")
+                        + " AND post." + dateSearchField + " <= " + BusinessEntityUtils.getDateString(endDate, "'", "YMD", "-") + ")"
+                        + searchTextAndClause
+                        + " ORDER BY post." + dateSearchField + " DESC";
+                break;
+        }
+        
+        try {
+            foundPosts = em.createQuery(searchQuery, Post.class).getResultList();
+            if (foundPosts == null) {
+                foundPosts = new ArrayList<>();
+            }
+        } catch (Exception e) {
+            System.out.println(e);
+            return null;
+        }
+        
+        return foundPosts;
+    }
+    public static List<Post> findActive(
+            EntityManager em,
+            String value,
+            int maxResults) {
+        
+        try {
+            
+            List<Post> posts
+                    = em.createQuery("SELECT p FROM Post p WHERE (p.name like '%"
+                            + value + "%'"
+                                    + " OR p.number like '%"
+                            + value + "%')"
+                                    + " AND p.active = 1"
+                                    + " ORDER BY p.id", Post.class).setMaxResults(maxResults).getResultList();
+            return posts;
+        } catch (Exception e) {
+            System.out.println(e);
+            return new ArrayList<>();
+        }
+    }
+    public static List<Post> find(
+            EntityManager em, String value, int maxResults) {
+        
+        try {
+            
+            List<Post> posts
+                    = em.createQuery("SELECT p FROM Post p WHERE p.name like '%"
+                            + value + "%'"
+                                    + " OR p.number like '%"
+                            + value + "%'"
+                                    + " ORDER BY p.id", Post.class).
+                            setMaxResults(maxResults).
+                            getResultList();
+            
+            return posts;
+            
+        } catch (Exception e) {
+            System.out.println(e);
+            return new ArrayList<>();
+        }
+    }
+    public static Post findById(EntityManager em, Long Id) {
+        
+        return em.find(Post.class, Id);
+    }
+    public static List<Post> findAll(EntityManager em) {
+        
+        try {
+            return em.createNamedQuery("findAllPosts", Post.class).getResultList();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+    public static List<Post> findAllActive(EntityManager em) {
+        
+        try {
+            
+            return em.createQuery("SELECT p FROM Post p "
+                    + "WHERE p.active = 1", Post.class).getResultList();
+            
+        } catch (Exception e) {
+            System.out.println(e);
+            return new ArrayList<>();
+        }
+    }
+    public static List<Post> findAllActive(
+            EntityManager em, int maxResults) {
+        
+        try {
+            
+            return em.createQuery("SELECT p FROM Post p "
+                    + "WHERE p.active = 1",
+                    Post.class).setMaxResults(maxResults).getResultList();
+            
+        } catch (Exception e) {
+            System.out.println(e);
+            return new ArrayList<>();
+        }
+    }
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
@@ -65,18 +261,12 @@ public class Post implements Document, Comparable, BusinessEntity {
     private String number;
     private String enforcement;
     private Boolean autoGenerateNumber;
-    @Temporal(javax.persistence.TemporalType.DATE)
-    private Date dateRevised;
-    @Temporal(javax.persistence.TemporalType.DATE)
-    private Date dateConfirmed;
-    @Temporal(javax.persistence.TemporalType.DATE)
-    private Date datePublished;
-    @Temporal(javax.persistence.TemporalType.DATE)
-    private Date dateRevisionDue;
-    @Temporal(javax.persistence.TemporalType.DATE)
-    private Date dateEntered;
-    @Temporal(javax.persistence.TemporalType.DATE)
-    private Date dateEdited;
+    private LocalDateTime dateRevised;
+    private LocalDateTime dateConfirmed;
+    private LocalDateTime datePublished;
+    private LocalDateTime dateRevisionDue;
+    private LocalDateTime dateEntered;
+    private LocalDateTime dateEdited;
     private String url;
     @OneToOne(cascade = CascadeType.REFRESH)
     private Classification classification;
@@ -142,22 +332,22 @@ public class Post implements Document, Comparable, BusinessEntity {
     }
 
     @Override
-    public Date getDateEntered() {
+    public LocalDateTime getDateEntered() {
         return dateEntered;
     }
 
     @Override
-    public void setDateEntered(Date dateEntered) {
+    public void setDateEntered(LocalDateTime dateEntered) {
         this.dateEntered = dateEntered;
     }
 
     @Override
-    public Date getDateEdited() {
+    public LocalDateTime getDateEdited() {
         return dateEdited;
     }
 
     @Override
-    public void setDateEdited(Date dateEdited) {
+    public void setDateEdited(LocalDateTime dateEdited) {
         this.dateEdited = dateEdited;
     }
 
@@ -348,35 +538,35 @@ public class Post implements Document, Comparable, BusinessEntity {
         this.enforcement = enforcement;
     }
 
-    public Date getDateRevised() {
+    public LocalDateTime getDateRevised() {
         return dateRevised;
     }
 
-    public void setDateRevised(Date dateRevised) {
+    public void setDateRevised(LocalDateTime dateRevised) {
         this.dateRevised = dateRevised;
     }
 
-    public Date getDateConfirmed() {
+    public LocalDateTime getDateConfirmed() {
         return dateConfirmed;
     }
 
-    public void setDateConfirmed(Date dateConfirmed) {
+    public void setDateConfirmed(LocalDateTime dateConfirmed) {
         this.dateConfirmed = dateConfirmed;
     }
 
-    public Date getDatePublished() {
+    public LocalDateTime getDatePublished() {
         return datePublished;
     }
 
-    public void setDatePublished(Date datePublished) {
+    public void setDatePublished(LocalDateTime datePublished) {
         this.datePublished = datePublished;
     }
 
-    public Date getDateRevisionDue() {
+    public LocalDateTime getDateRevisionDue() {
         return dateRevisionDue;
     }
 
-    public void setDateRevisionDue(Date dateRevisionDue) {
+    public void setDateRevisionDue(LocalDateTime dateRevisionDue) {
         this.dateRevisionDue = dateRevisionDue;
     }
 
@@ -396,209 +586,6 @@ public class Post implements Document, Comparable, BusinessEntity {
         this.status = status;
     }
 
-    public static Post findActiveByName(EntityManager em, String value,
-            Boolean ignoreCase) {
-
-        List<Post> posts;
-
-        try {
-
-            if (ignoreCase) {
-                posts = em.createQuery("SELECT p FROM Post p "
-                        + "WHERE UPPER(p.name) "
-                        + "= '" + value.toUpperCase() + "'"
-                        + " AND p.active = 1", Post.class).getResultList();
-            } else {
-                posts = em.createQuery("SELECT p FROM Post p "
-                        + "WHERE p.name "
-                        + "= '" + value + "'"
-                        + " AND p.active = 1", Post.class).getResultList();
-            }
-
-            if (!posts.isEmpty()) {
-                return posts.get(0);
-            }
-            return null;
-        } catch (Exception e) {
-            System.out.println(e);
-            return null;
-        }
-    }
-
-    public static Post findByName(EntityManager em, String value,
-            Boolean ignoreCase) {
-
-        List<Post> posts;
-
-        try {
-
-            if (ignoreCase) {
-                posts = em.createQuery("SELECT p FROM Post p "
-                        + "WHERE UPPER(p.name) "
-                        + "= '" + value.toUpperCase() + "'",
-                        Post.class).getResultList();
-            } else {
-                posts = em.createQuery("SELECT p FROM Post p "
-                        + "WHERE p.name "
-                        + "= '" + value + "'",
-                        Post.class).getResultList();
-            }
-
-            if (!posts.isEmpty()) {
-                return posts.get(0);
-            }
-            return null;
-        } catch (Exception e) {
-            System.out.println(e);
-            return null;
-        }
-    }
-
-    public static List<Post> findByDateSearchField(
-            EntityManager em,
-            String dateSearchField,
-            String searchType,
-            String originalSearchText,
-            Date startDate,
-            Date endDate) {
-
-        List<Post> foundPosts;
-        String searchQuery = null;
-        String searchTextAndClause = "";
-        String searchText = originalSearchText;
-        switch (searchType) {
-            case "General":
-                if (!searchText.equals("")) {
-                    searchTextAndClause
-                            = " AND ("
-                            + " UPPER(post.number) LIKE '%" + searchText.toUpperCase() + "%'"
-                            + " OR UPPER(post.comments) LIKE '%" + searchText.toUpperCase() + "%'"
-                            + " OR UPPER(post.notes) LIKE '%" + searchText.toUpperCase() + "%'"
-                            + " OR UPPER(post.url) LIKE '%" + searchText.toUpperCase() + "%'"
-                            + " OR UPPER(classification.name) LIKE '%" + searchText.toUpperCase() + "%'"
-                            + " OR UPPER(post.documentForm) LIKE '%" + searchText.toUpperCase() + "%'"
-                            + " )";
-                }
-                searchQuery
-                        = "SELECT post FROM Post post"
-                        + " JOIN post.classification classification"
-                        + " WHERE (post." + dateSearchField + " >= " + BusinessEntityUtils.getDateString(startDate, "'", "YMD", "-")
-                        + " AND post." + dateSearchField + " <= " + BusinessEntityUtils.getDateString(endDate, "'", "YMD", "-") + ")"
-                        + searchTextAndClause
-                        + " ORDER BY post." + dateSearchField + " DESC";
-                break;
-            case "By type":
-                searchTextAndClause
-                        = " AND ("
-                        + " UPPER(t.name) = '" + searchText.toUpperCase() + "'"
-                        + " )";
-                searchQuery
-                        = "SELECT post FROM Post post"
-                        + " JOIN post.documentType t"
-                        + " WHERE (post." + dateSearchField + " >= " + BusinessEntityUtils.getDateString(startDate, "'", "YMD", "-")
-                        + " AND post." + dateSearchField + " <= " + BusinessEntityUtils.getDateString(endDate, "'", "YMD", "-") + ")"
-                        + searchTextAndClause
-                        + " ORDER BY post." + dateSearchField + " DESC";
-                break;
-        }
-
-        try {
-            foundPosts = em.createQuery(searchQuery, Post.class).getResultList();
-            if (foundPosts == null) {
-                foundPosts = new ArrayList<>();
-            }
-        } catch (Exception e) {
-            System.out.println(e);
-            return null;
-        }
-
-        return foundPosts;
-    }
-
-    public static List<Post> findActive(
-            EntityManager em,
-            String value,
-            int maxResults) {
-
-        try {
-
-            List<Post> posts
-                    = em.createQuery("SELECT p FROM Post p WHERE (p.name like '%"
-                            + value + "%'"
-                            + " OR p.number like '%"
-                            + value + "%')"
-                            + " AND p.active = 1"
-                            + " ORDER BY p.id", Post.class).setMaxResults(maxResults).getResultList();
-            return posts;
-        } catch (Exception e) {
-            System.out.println(e);
-            return new ArrayList<>();
-        }
-    }
-
-    public static List<Post> find(
-            EntityManager em, String value, int maxResults) {
-
-        try {
-
-            List<Post> posts
-                    = em.createQuery("SELECT p FROM Post p WHERE p.name like '%"
-                            + value + "%'"
-                            + " OR p.number like '%"
-                            + value + "%'"
-                            + " ORDER BY p.id", Post.class).
-                            setMaxResults(maxResults).
-                            getResultList();
-
-            return posts;
-
-        } catch (Exception e) {
-            System.out.println(e);
-            return new ArrayList<>();
-        }
-    }
-
-    public static Post findById(EntityManager em, Long Id) {
-
-        return em.find(Post.class, Id);
-    }
-
-    public static List<Post> findAll(EntityManager em) {
-
-        try {
-            return em.createNamedQuery("findAllPosts", Post.class).getResultList();
-        } catch (Exception e) {
-            return null;
-        }
-    }
-
-    public static List<Post> findAllActive(EntityManager em) {
-
-        try {
-
-            return em.createQuery("SELECT p FROM Post p "
-                    + "WHERE p.active = 1", Post.class).getResultList();
-
-        } catch (Exception e) {
-            System.out.println(e);
-            return new ArrayList<>();
-        }
-    }
-
-    public static List<Post> findAllActive(
-            EntityManager em, int maxResults) {
-
-        try {
-
-            return em.createQuery("SELECT p FROM Post p "
-                    + "WHERE p.active = 1",
-                    Post.class).setMaxResults(maxResults).getResultList();
-
-        } catch (Exception e) {
-            System.out.println(e);
-            return new ArrayList<>();
-        }
-    }
 
     public String getUsable() {
         if (getActive()) {

--- a/src/main/java/jm/com/dpbennett/business/entity/fm/AccPacCustomer.java
+++ b/src/main/java/jm/com/dpbennett/business/entity/fm/AccPacCustomer.java
@@ -20,17 +20,18 @@ Email: info@dpbennett.com.jm
 
 package jm.com.dpbennett.business.entity.fm;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import java.io.Serializable;
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EntityManager;
-import javax.persistence.Id;
-import javax.persistence.Table;
-import javax.persistence.Transient;
 import jm.com.dpbennett.business.entity.BusinessEntity;
 import jm.com.dpbennett.business.entity.Person;
 import jm.com.dpbennett.business.entity.sm.SystemOption;
@@ -46,6 +47,65 @@ import jm.com.dpbennett.business.entity.util.ReturnMessage;
 public class AccPacCustomer implements Serializable, BusinessEntity {
 
     private static final long serialVersionUID = 1L;
+    private static final System.Logger LOG = System.getLogger(AccPacCustomer.class.getName());
+    
+    public static List<AccPacCustomer> findAllByName(EntityManager em, String value) {
+        
+        try {
+            
+            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
+            
+            List<AccPacCustomer> clients;
+            clients = em.createQuery(
+                    "SELECT a FROM AccPacCustomer a"
+                            + " WHERE UPPER(a.customerName)"
+                            + " LIKE '" + value.toUpperCase().trim()
+                            + "%' ORDER BY a.customerName", AccPacCustomer.class).getResultList();
+            return clients;
+        } catch (Exception e) {
+            System.out.println(e);
+            return new ArrayList<>();
+        }
+    }
+    public static List<AccPacCustomer> findAllByNameAndId(EntityManager em, String value) {
+        
+        try {
+            
+            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
+            
+            List<AccPacCustomer> clients;
+            clients = em.createQuery(
+                    "SELECT a FROM AccPacCustomer a"
+                            + " WHERE UPPER(a.customerName) LIKE '" + value.toUpperCase().trim() + "%'"
+                                    + " OR UPPER(a.idCust) LIKE '" + value.toUpperCase().trim() + "%'"
+                                            + " ORDER BY a.customerName", AccPacCustomer.class).getResultList();
+            return clients;
+        } catch (Exception e) {
+            System.out.println(e);
+            return new ArrayList<>();
+        }
+    }
+    public static AccPacCustomer findByName(EntityManager em, String value) {
+        
+        try {
+            
+            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
+            
+            List<AccPacCustomer> customers = em.createQuery(
+                    "SELECT a FROM AccPacCustomer a"
+                            + " WHERE UPPER(a.customerName)"
+                            + " LIKE '" + value.toUpperCase().trim()
+                            + "%' ORDER BY a.customerName", AccPacCustomer.class).getResultList();
+            
+            if (!customers.isEmpty()) {
+                return customers.get(0);
+            }
+            return null;
+        } catch (Exception e) {
+            System.out.println(e);
+            return null;
+        }
+    }
     @Id
     @Column(length = 12, name = "IDCUST")
     private String idCust;
@@ -238,65 +298,6 @@ public class AccPacCustomer implements Serializable, BusinessEntity {
         return getCustomerName();
     }
 
-    public static List<AccPacCustomer> findAllByName(EntityManager em, String value) {
-
-        try {
-
-            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
-
-            List<AccPacCustomer> clients;
-            clients = em.createQuery(
-                    "SELECT a FROM AccPacCustomer a"
-                    + " WHERE UPPER(a.customerName)"
-                    + " LIKE '" + value.toUpperCase().trim()
-                    + "%' ORDER BY a.customerName", AccPacCustomer.class).getResultList();
-            return clients;
-        } catch (Exception e) {
-            System.out.println(e);
-            return new ArrayList<>();
-        }
-    }
-
-    public static List<AccPacCustomer> findAllByNameAndId(EntityManager em, String value) {
-
-        try {
-
-            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
-
-            List<AccPacCustomer> clients;
-            clients = em.createQuery(
-                    "SELECT a FROM AccPacCustomer a"
-                    + " WHERE UPPER(a.customerName) LIKE '" + value.toUpperCase().trim() + "%'"
-                    + " OR UPPER(a.idCust) LIKE '" + value.toUpperCase().trim() + "%'"
-                    + " ORDER BY a.customerName", AccPacCustomer.class).getResultList();
-            return clients;
-        } catch (Exception e) {
-            System.out.println(e);
-            return new ArrayList<>();
-        }
-    }
-
-    public static AccPacCustomer findByName(EntityManager em, String value) {
-
-        try {
-
-            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
-
-            List<AccPacCustomer> customers = em.createQuery(
-                    "SELECT a FROM AccPacCustomer a"
-                    + " WHERE UPPER(a.customerName)"
-                    + " LIKE '" + value.toUpperCase().trim()
-                    + "%' ORDER BY a.customerName", AccPacCustomer.class).getResultList();
-
-            if (!customers.isEmpty()) {
-                return customers.get(0);
-            }
-            return null;
-        } catch (Exception e) {
-            System.out.println(e);
-            return null;
-        }
-    }
 
     @Override
     public Boolean getIsDirty() {
@@ -377,22 +378,22 @@ public class AccPacCustomer implements Serializable, BusinessEntity {
     }
 
     @Override
-    public Date getDateEntered() {
+    public LocalDateTime getDateEntered() {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public void setDateEntered(Date dateEntered) {
+    public void setDateEntered(LocalDateTime dateEntered) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public Date getDateEdited() {
+    public LocalDateTime getDateEdited() {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public void setDateEdited(Date dateEdited) {
+    public void setDateEdited(LocalDateTime dateEdited) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 

--- a/src/main/java/jm/com/dpbennett/business/entity/fm/AccPacCustomerOrg.java
+++ b/src/main/java/jm/com/dpbennett/business/entity/fm/AccPacCustomerOrg.java
@@ -19,17 +19,18 @@ Email: info@dpbennett.com.jm
  */
 package jm.com.dpbennett.business.entity.fm;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import java.io.Serializable;
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EntityManager;
-import javax.persistence.Id;
-import javax.persistence.Table;
-import javax.persistence.Transient;
 import jm.com.dpbennett.business.entity.BusinessEntity;
 import jm.com.dpbennett.business.entity.Person;
 import jm.com.dpbennett.business.entity.sm.SystemOption;
@@ -45,6 +46,62 @@ import jm.com.dpbennett.business.entity.util.ReturnMessage;
 public class AccPacCustomerOrg implements Serializable, BusinessEntity {
 
     private static final long serialVersionUID = 1L;
+    private static final System.Logger LOG = System.getLogger(AccPacCustomerOrg.class.getName());
+    
+    public static List<AccPacCustomerOrg> findAllByName(EntityManager em, String value) {
+        
+        try {
+            
+            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
+            
+            List<AccPacCustomerOrg> clients;
+            clients = em.createQuery("SELECT a FROM AccPacCustomer a"
+                    + " WHERE UPPER(a.customerName)"
+                    + " LIKE '" + value.toUpperCase().trim()
+                    + "%' ORDER BY a.customerName", AccPacCustomerOrg.class).getResultList();
+            return clients;
+        } catch (Exception e) {
+            System.out.println(e);
+            return new ArrayList<>();
+        }
+    }
+    public static List<AccPacCustomerOrg> findAllByNameAndId(EntityManager em, String value) {
+        
+        try {
+            
+            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
+            
+            List<AccPacCustomerOrg> clients;
+            clients = em.createQuery("SELECT a FROM AccPacCustomer a"
+                    + " WHERE UPPER(a.customerName) LIKE '" + value.toUpperCase().trim() + "%'"
+                            + " OR UPPER(a.idCust) LIKE '" + value.toUpperCase().trim() + "%'"
+                                    + " ORDER BY a.customerName", AccPacCustomerOrg.class).getResultList();
+            return clients;
+        } catch (Exception e) {
+            System.out.println(e);
+            return new ArrayList<>();
+        }
+    }
+    public static AccPacCustomerOrg findByName(EntityManager em, String value) {
+        
+        try {
+            
+            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
+            
+            List<AccPacCustomerOrg> customers = em.createQuery("SELECT a FROM AccPacCustomer a"
+                    + " WHERE UPPER(a.customerName)"
+                    + " LIKE '" + value.toUpperCase().trim()
+                    + "%' ORDER BY a.customerName", AccPacCustomerOrg.class).getResultList();
+            
+            if (!customers.isEmpty()) {
+                return customers.get(0);
+            }
+            return null;
+        } catch (Exception e) {
+            System.out.println(e);
+            return null;
+        }
+    }
     @Id
     @Column(length = 12, name = "IDCUST")
     private String idCust;
@@ -237,62 +294,6 @@ public class AccPacCustomerOrg implements Serializable, BusinessEntity {
         return getCustomerName();
     }
 
-    public static List<AccPacCustomerOrg> findAllByName(EntityManager em, String value) {
-
-        try {
-
-            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
-
-            List<AccPacCustomerOrg> clients;
-            clients = em.createQuery("SELECT a FROM AccPacCustomer a"
-                    + " WHERE UPPER(a.customerName)"
-                    + " LIKE '" + value.toUpperCase().trim()
-                    + "%' ORDER BY a.customerName", AccPacCustomerOrg.class).getResultList();
-            return clients;
-        } catch (Exception e) {
-            System.out.println(e);
-            return new ArrayList<>();
-        }
-    }
-
-    public static List<AccPacCustomerOrg> findAllByNameAndId(EntityManager em, String value) {
-
-        try {
-
-            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
-
-            List<AccPacCustomerOrg> clients;
-            clients = em.createQuery("SELECT a FROM AccPacCustomer a"
-                    + " WHERE UPPER(a.customerName) LIKE '" + value.toUpperCase().trim() + "%'"
-                    + " OR UPPER(a.idCust) LIKE '" + value.toUpperCase().trim() + "%'"
-                    + " ORDER BY a.customerName", AccPacCustomerOrg.class).getResultList();
-            return clients;
-        } catch (Exception e) {
-            System.out.println(e);
-            return new ArrayList<>();
-        }
-    }
-
-    public static AccPacCustomerOrg findByName(EntityManager em, String value) {
-
-        try {
-
-            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
-
-            List<AccPacCustomerOrg> customers = em.createQuery("SELECT a FROM AccPacCustomer a"
-                    + " WHERE UPPER(a.customerName)"
-                    + " LIKE '" + value.toUpperCase().trim()
-                    + "%' ORDER BY a.customerName", AccPacCustomerOrg.class).getResultList();
-
-            if (!customers.isEmpty()) {
-                return customers.get(0);
-            }
-            return null;
-        } catch (Exception e) {
-            System.out.println(e);
-            return null;
-        }
-    }
 
     @Override
     public Boolean getIsDirty() {
@@ -373,22 +374,22 @@ public class AccPacCustomerOrg implements Serializable, BusinessEntity {
     }
 
     @Override
-    public Date getDateEntered() {
+    public LocalDateTime getDateEntered() {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public void setDateEntered(Date dateEntered) {
+    public void setDateEntered(LocalDateTime dateEntered) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public Date getDateEdited() {
+    public LocalDateTime getDateEdited() {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public void setDateEdited(Date dateEdited) {
+    public void setDateEdited(LocalDateTime dateEdited) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 

--- a/src/main/java/jm/com/dpbennett/business/entity/fm/AccPacDocument.java
+++ b/src/main/java/jm/com/dpbennett/business/entity/fm/AccPacDocument.java
@@ -19,21 +19,22 @@ Email: info@dpbennett.com.jm
  */
 package jm.com.dpbennett.business.entity.fm;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EntityManager;
-import javax.persistence.Id;
-import javax.persistence.Table;
-import javax.persistence.Transient;
 import jm.com.dpbennett.business.entity.BusinessEntity;
 import jm.com.dpbennett.business.entity.Person;
 import jm.com.dpbennett.business.entity.sm.SystemOption;
@@ -49,6 +50,67 @@ import jm.com.dpbennett.business.entity.util.ReturnMessage;
 public class AccPacDocument implements Serializable, BusinessEntity {
 
     private static final long serialVersionUID = 1L;
+    private static final System.Logger LOG = System.getLogger(AccPacDocument.class.getName());
+    
+    public static List<AccPacDocument> findAccPacDocumentsByCustomerId(EntityManager em, String customerId) {
+        try {
+            List<AccPacDocument> docs = em.createQuery("SELECT d FROM AccPacDocument d "
+                    + "WHERE d.idCust "
+                    + "LIKE '" + customerId + "%'", AccPacDocument.class).getResultList();
+            
+            if (docs == null) {
+                return new ArrayList<>();
+            } else {
+                return docs;
+            }
+        } catch (Exception e) {
+            System.out.println(e);
+            return new ArrayList<>();
+        }
+    }
+    public static List<AccPacDocument> findAccPacInvoicesByCustomerId(EntityManager em, String customerId) {
+        try {
+            List<AccPacDocument> docs = em.createQuery("SELECT d FROM AccPacDocument d "
+                    + "WHERE d.idCust "
+                    + "LIKE '" + customerId + "%' AND d.documentType = 1", AccPacDocument.class).getResultList();
+            
+            if (docs == null) {
+                return new ArrayList<>();
+            } else {
+                return docs;
+            }
+        } catch (Exception e) {
+            System.out.println(e);
+            return new ArrayList<>();
+        }
+    }
+    public static List<AccPacDocument> findAccPacInvoicesDueByCustomerId(EntityManager em,
+            String customerId, Boolean includePrepayments) {
+        
+        List<AccPacDocument> foundsDocs;
+        
+        try {
+            if (includePrepayments) {
+                foundsDocs = em.createQuery("SELECT d FROM AccPacDocument d "
+                        + "WHERE d.idCust "
+                        + "LIKE '" + customerId + "%' AND d.fullyPaid = 0 ORDER BY d.dueDate DESC", AccPacDocument.class).getResultList();
+            } else {
+                foundsDocs = em.createQuery("SELECT d FROM AccPacDocument d "
+                        + "WHERE d.idCust " // NB: 50 == Prepayment transaction type
+                        + "LIKE '" + customerId + "%' AND d.fullyPaid = 0 AND d.transactionType <> 50 ORDER BY d.dueDate DESC", AccPacDocument.class).getResultList();
+            }
+            
+            if (foundsDocs != null) {
+                return foundsDocs;
+            } else {
+                return new ArrayList<>();
+            }
+            
+        } catch (Exception e) {
+            System.out.println(e);
+            return new ArrayList<>();
+        }
+    }
     @Id
     @Column(length = 22, name = "IDINVC", nullable = false)
     private String idInvc;
@@ -329,67 +391,6 @@ public class AccPacDocument implements Serializable, BusinessEntity {
         return "jm.com.dpbennett.entity.AccPacDocument[id=" + idInvc + "]";
     }
 
-    public static List<AccPacDocument> findAccPacDocumentsByCustomerId(EntityManager em, String customerId) {
-        try {
-            List<AccPacDocument> docs = em.createQuery("SELECT d FROM AccPacDocument d "
-                    + "WHERE d.idCust "
-                    + "LIKE '" + customerId + "%'", AccPacDocument.class).getResultList();
-
-            if (docs == null) {
-                return new ArrayList<>();
-            } else {
-                return docs;
-            }
-        } catch (Exception e) {
-            System.out.println(e);
-            return new ArrayList<>();
-        }
-    }
-
-    public static List<AccPacDocument> findAccPacInvoicesByCustomerId(EntityManager em, String customerId) {
-        try {
-            List<AccPacDocument> docs = em.createQuery("SELECT d FROM AccPacDocument d "
-                    + "WHERE d.idCust "
-                    + "LIKE '" + customerId + "%' AND d.documentType = 1", AccPacDocument.class).getResultList();
-
-            if (docs == null) {
-                return new ArrayList<>();
-            } else {
-                return docs;
-            }
-        } catch (Exception e) {
-            System.out.println(e);
-            return new ArrayList<>();
-        }
-    }
-
-    public static List<AccPacDocument> findAccPacInvoicesDueByCustomerId(EntityManager em,
-            String customerId, Boolean includePrepayments) {
-
-        List<AccPacDocument> foundsDocs;
-
-        try {
-            if (includePrepayments) {
-                foundsDocs = em.createQuery("SELECT d FROM AccPacDocument d "
-                        + "WHERE d.idCust "
-                        + "LIKE '" + customerId + "%' AND d.fullyPaid = 0 ORDER BY d.dueDate DESC", AccPacDocument.class).getResultList();
-            } else {
-                foundsDocs = em.createQuery("SELECT d FROM AccPacDocument d "
-                        + "WHERE d.idCust " // NB: 50 == Prepayment transaction type
-                        + "LIKE '" + customerId + "%' AND d.fullyPaid = 0 AND d.transactionType <> 50 ORDER BY d.dueDate DESC", AccPacDocument.class).getResultList();
-            }
-
-            if (foundsDocs != null) {
-                return foundsDocs;
-            } else {
-                return new ArrayList<>();
-            }
-
-        } catch (Exception e) {
-            System.out.println(e);
-            return new ArrayList<>();
-        }
-    }
 
     @Override
     public Long getId() {
@@ -464,22 +465,22 @@ public class AccPacDocument implements Serializable, BusinessEntity {
     }
 
     @Override
-    public Date getDateEntered() {
+    public LocalDateTime getDateEntered() {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public void setDateEntered(Date dateEntered) {
+    public void setDateEntered(LocalDateTime dateEntered) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public Date getDateEdited() {
+    public LocalDateTime getDateEdited() {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public void setDateEdited(Date dateEdited) {
+    public void setDateEdited(LocalDateTime dateEdited) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 

--- a/src/main/java/jm/com/dpbennett/business/entity/fm/AccPacDocumentOrg.java
+++ b/src/main/java/jm/com/dpbennett/business/entity/fm/AccPacDocumentOrg.java
@@ -20,21 +20,22 @@ Email: info@dpbennett.com.jm
 
 package jm.com.dpbennett.business.entity.fm;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EntityManager;
-import javax.persistence.Id;
-import javax.persistence.Table;
-import javax.persistence.Transient;
 import jm.com.dpbennett.business.entity.BusinessEntity;
 import jm.com.dpbennett.business.entity.Person;
 import jm.com.dpbennett.business.entity.sm.SystemOption;
@@ -50,6 +51,67 @@ import jm.com.dpbennett.business.entity.util.ReturnMessage;
 public class AccPacDocumentOrg implements Serializable, BusinessEntity {
 
     private static final long serialVersionUID = 1L;
+    private static final System.Logger LOG = System.getLogger(AccPacDocumentOrg.class.getName());
+    
+    public static List<AccPacDocumentOrg> findAccPacDocumentsByCustomerId(EntityManager em, String customerId) {
+        try {
+            List<AccPacDocumentOrg> docs = em.createQuery("SELECT d FROM AccPacDocument d "
+                    + "WHERE d.idCust "
+                    + "LIKE '" + customerId + "%'", AccPacDocumentOrg.class).getResultList();
+            
+            if (docs == null) {
+                return new ArrayList<>();
+            } else {
+                return docs;
+            }
+        } catch (Exception e) {
+            System.out.println(e);
+            return new ArrayList<>();
+        }
+    }
+    public static List<AccPacDocumentOrg> findAccPacInvoicesByCustomerId(EntityManager em, String customerId) {
+        try {
+            List<AccPacDocumentOrg> docs = em.createQuery("SELECT d FROM AccPacDocument d "
+                    + "WHERE d.idCust "
+                    + "LIKE '" + customerId + "%' AND d.documentType = 1", AccPacDocumentOrg.class).getResultList();
+            
+            if (docs == null) {
+                return new ArrayList<>();
+            } else {
+                return docs;
+            }
+        } catch (Exception e) {
+            System.out.println(e);
+            return new ArrayList<>();
+        }
+    }
+    public static List<AccPacDocumentOrg> findAccPacInvoicesDueByCustomerId(EntityManager em,
+            String customerId, Boolean includePrepayments) {
+        
+        List<AccPacDocumentOrg> foundsDocs;
+        
+        try {
+            if (includePrepayments) {
+                foundsDocs = em.createQuery("SELECT d FROM AccPacDocument d "
+                        + "WHERE d.idCust "
+                        + "LIKE '" + customerId + "%' AND d.fullyPaid = 0 ORDER BY d.dueDate DESC", AccPacDocumentOrg.class).getResultList();
+            } else {
+                foundsDocs = em.createQuery("SELECT d FROM AccPacDocument d "
+                        + "WHERE d.idCust " // NB: 50 == Prepayment transaction type
+                        + "LIKE '" + customerId + "%' AND d.fullyPaid = 0 AND d.transactionType <> 50 ORDER BY d.dueDate DESC", AccPacDocumentOrg.class).getResultList();
+            }
+            
+            if (foundsDocs != null) {
+                return foundsDocs;
+            } else {
+                return new ArrayList<>();
+            }
+            
+        } catch (Exception e) {
+            System.out.println(e);
+            return new ArrayList<>();
+        }
+    }
     @Id
     @Column(length = 22, name = "IDINVC")
     private String idInvc;
@@ -330,67 +392,6 @@ public class AccPacDocumentOrg implements Serializable, BusinessEntity {
         return "jm.com.dpbennett.entity.AccPacDocument[id=" + idInvc + "]";
     }
 
-    public static List<AccPacDocumentOrg> findAccPacDocumentsByCustomerId(EntityManager em, String customerId) {
-        try {
-            List<AccPacDocumentOrg> docs = em.createQuery("SELECT d FROM AccPacDocument d "
-                    + "WHERE d.idCust "
-                    + "LIKE '" + customerId + "%'", AccPacDocumentOrg.class).getResultList();
-
-            if (docs == null) {
-                return new ArrayList<>();
-            } else {
-                return docs;
-            }
-        } catch (Exception e) {
-            System.out.println(e);
-            return new ArrayList<>();
-        }
-    }
-
-    public static List<AccPacDocumentOrg> findAccPacInvoicesByCustomerId(EntityManager em, String customerId) {
-        try {
-            List<AccPacDocumentOrg> docs = em.createQuery("SELECT d FROM AccPacDocument d "
-                    + "WHERE d.idCust "
-                    + "LIKE '" + customerId + "%' AND d.documentType = 1", AccPacDocumentOrg.class).getResultList();
-
-            if (docs == null) {
-                return new ArrayList<>();
-            } else {
-                return docs;
-            }
-        } catch (Exception e) {
-            System.out.println(e);
-            return new ArrayList<>();
-        }
-    }
-
-    public static List<AccPacDocumentOrg> findAccPacInvoicesDueByCustomerId(EntityManager em,
-            String customerId, Boolean includePrepayments) {
-
-        List<AccPacDocumentOrg> foundsDocs;
-
-        try {
-            if (includePrepayments) {
-                foundsDocs = em.createQuery("SELECT d FROM AccPacDocument d "
-                        + "WHERE d.idCust "
-                        + "LIKE '" + customerId + "%' AND d.fullyPaid = 0 ORDER BY d.dueDate DESC", AccPacDocumentOrg.class).getResultList();
-            } else {
-                foundsDocs = em.createQuery("SELECT d FROM AccPacDocument d "
-                        + "WHERE d.idCust " // NB: 50 == Prepayment transaction type
-                        + "LIKE '" + customerId + "%' AND d.fullyPaid = 0 AND d.transactionType <> 50 ORDER BY d.dueDate DESC", AccPacDocumentOrg.class).getResultList();
-            }
-
-            if (foundsDocs != null) {
-                return foundsDocs;
-            } else {
-                return new ArrayList<>();
-            }
-
-        } catch (Exception e) {
-            System.out.println(e);
-            return new ArrayList<>();
-        }
-    }
 
     @Override
     public Long getId() {
@@ -465,22 +466,22 @@ public class AccPacDocumentOrg implements Serializable, BusinessEntity {
     }
 
     @Override
-    public Date getDateEntered() {
+    public LocalDateTime getDateEntered() {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public void setDateEntered(Date dateEntered) {
+    public void setDateEntered(LocalDateTime dateEntered) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public Date getDateEdited() {
+    public LocalDateTime getDateEdited() {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public void setDateEdited(Date dateEdited) {
+    public void setDateEdited(LocalDateTime dateEdited) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 

--- a/src/main/java/jm/com/dpbennett/business/entity/fm/AccountingCode.java
+++ b/src/main/java/jm/com/dpbennett/business/entity/fm/AccountingCode.java
@@ -20,20 +20,20 @@ Email: info@dpbennett.com.jm
 
 package jm.com.dpbennett.business.entity.fm;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import java.io.Serializable;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EntityManager;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.NamedQueries;
-import javax.persistence.NamedQuery;
-import javax.persistence.Table;
-import javax.persistence.Transient;
 import jm.com.dpbennett.business.entity.BusinessEntity;
 import jm.com.dpbennett.business.entity.Person;
 import jm.com.dpbennett.business.entity.sm.SystemOption;
@@ -53,6 +53,121 @@ import jm.com.dpbennett.business.entity.util.ReturnMessage;
 public class AccountingCode implements Serializable, BusinessEntity {
 
     private static final long serialVersionUID = 1L;
+    private static final System.Logger LOG = System.getLogger(AccountingCode.class.getName());
+    
+    public static List<AccountingCode> findAll(EntityManager em) {
+        
+        try {
+            List<AccountingCode> codes = em.createNamedQuery("findAllAccountingCodes", AccountingCode.class).getResultList();
+            
+            return codes;
+            
+        } catch (Exception e) {
+            System.out.println(e);
+            return null;
+        }
+    }
+    public static List<AccountingCode> findAll(EntityManager em, String value) {
+        
+        try {
+            
+            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
+            
+            List<AccountingCode> accountingCodes
+                    = em.createQuery(
+                            "SELECT a FROM AccountingCode a WHERE UPPER(a.name) LIKE '%" + value.toUpperCase().trim()
+                                    + "%' OR UPPER(a.description) LIKE '%" + value.toUpperCase().trim()
+                                    + "%' OR UPPER(a.code) LIKE '%" + value.toUpperCase().trim()
+                                    + "%' OR UPPER(a.account) LIKE '%" + value.toUpperCase().trim()
+                                    + "%' OR UPPER(a.type) LIKE '%" + value.toUpperCase().trim()
+                                    + "%' OR UPPER(a.abbreviation) LIKE '%" + value.toUpperCase().trim()
+                                    + "%' ORDER BY a.name",
+                            AccountingCode.class).getResultList();
+            return accountingCodes;
+        } catch (Exception e) {
+            System.out.println(e);
+            return new ArrayList<>();
+        }
+    }
+    public static List<AccountingCode> findAllActive(EntityManager em, String value) {
+        
+        try {
+            
+            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
+            
+            List<AccountingCode> accountingCodes
+                    = em.createQuery("SELECT a FROM AccountingCode a WHERE (UPPER(a.name) LIKE '%" + value.toUpperCase().trim()
+                            + "%' OR UPPER(a.description) LIKE '%" + value.toUpperCase().trim()
+                            + "%' OR UPPER(a.code) LIKE '%" + value.toUpperCase().trim()
+                            + "%' OR UPPER(a.account) LIKE '%" + value.toUpperCase().trim()
+                            + "%' OR UPPER(a.type) LIKE '%" + value.toUpperCase().trim()
+                            + "%' OR UPPER(a.abbreviation) LIKE '%" + value.toUpperCase().trim()
+                            + "%') AND (a.active = 1 OR a.active IS NULL) ORDER BY a.name",
+                            AccountingCode.class).getResultList();
+            return accountingCodes;
+        } catch (Exception e) {
+            System.out.println(e);
+            return new ArrayList<>();
+        }
+    }
+    public static AccountingCode findByName(EntityManager em, String value) {
+        
+        try {
+            
+            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
+            
+            List<AccountingCode> accountingCodes = em.createQuery("SELECT a FROM AccountingCode a "
+                    + "WHERE UPPER(a.name) "
+                    + "= '" + value.toUpperCase() + "'", AccountingCode.class).getResultList();
+            
+            if (!accountingCodes.isEmpty()) {
+                return accountingCodes.get(0);
+            }
+            
+            return null;
+        } catch (Exception e) {
+            System.out.println(e);
+            return null;
+        }
+    }
+    public static AccountingCode findByCode(EntityManager em, String value) {
+        
+        try {
+            
+            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
+            
+            List<AccountingCode> accountingCodes = em.createQuery("SELECT a FROM AccountingCode a "
+                    + "WHERE UPPER(a.code) "
+                    + "= '" + value.toUpperCase() + "'", AccountingCode.class).getResultList();
+            if (!accountingCodes.isEmpty()) {
+                return accountingCodes.get(0);
+            }
+            
+            return null;
+        } catch (Exception e) {
+            System.out.println(e);
+            
+            return null;
+        }
+    }
+    public static AccountingCode findActiveByCode(EntityManager em, String value) {
+        
+        try {
+            
+            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
+            
+            List<AccountingCode> accountingCodes = em.createQuery("SELECT a FROM AccountingCode a "
+                    + "WHERE UPPER(a.code) "
+                    + "= '" + value.toUpperCase() + "' AND (a.active = 1 OR a.active IS NULL)", AccountingCode.class).getResultList();
+            if (!accountingCodes.isEmpty()) {
+                return accountingCodes.get(0);
+            }
+            return null;
+        } catch (Exception e) {
+            System.out.println(e);
+            return null;
+        }
+    }
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
@@ -124,63 +239,6 @@ public class AccountingCode implements Serializable, BusinessEntity {
         this.code = code;
     }
 
-    public static List<AccountingCode> findAll(EntityManager em) {
-
-        try {
-            List<AccountingCode> codes = em.createNamedQuery("findAllAccountingCodes", AccountingCode.class).getResultList();
-
-            return codes;
-
-        } catch (Exception e) {
-            System.out.println(e);
-            return null;
-        }
-    }
-
-    public static List<AccountingCode> findAll(EntityManager em, String value) {
-
-        try {
-
-            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
-
-            List<AccountingCode> accountingCodes
-                    = em.createQuery(
-                            "SELECT a FROM AccountingCode a WHERE UPPER(a.name) LIKE '%" + value.toUpperCase().trim()
-                            + "%' OR UPPER(a.description) LIKE '%" + value.toUpperCase().trim()
-                            + "%' OR UPPER(a.code) LIKE '%" + value.toUpperCase().trim()
-                            + "%' OR UPPER(a.account) LIKE '%" + value.toUpperCase().trim()
-                            + "%' OR UPPER(a.type) LIKE '%" + value.toUpperCase().trim()
-                            + "%' OR UPPER(a.abbreviation) LIKE '%" + value.toUpperCase().trim()
-                            + "%' ORDER BY a.name",
-                            AccountingCode.class).getResultList();
-            return accountingCodes;
-        } catch (Exception e) {
-            System.out.println(e);
-            return new ArrayList<>();
-        }
-    }
-
-    public static List<AccountingCode> findAllActive(EntityManager em, String value) {
-
-        try {
-
-            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
-
-            List<AccountingCode> accountingCodes
-                    = em.createQuery("SELECT a FROM AccountingCode a WHERE (UPPER(a.name) LIKE '%" + value.toUpperCase().trim()
-                            + "%' OR UPPER(a.description) LIKE '%" + value.toUpperCase().trim()
-                            + "%' OR UPPER(a.code) LIKE '%" + value.toUpperCase().trim()
-                            + "%' OR UPPER(a.account) LIKE '%" + value.toUpperCase().trim()
-                            + "%' OR UPPER(a.type) LIKE '%" + value.toUpperCase().trim()
-                            + "%' OR UPPER(a.abbreviation) LIKE '%" + value.toUpperCase().trim()
-                            + "%') AND (a.active = 1 OR a.active IS NULL) ORDER BY a.name",
-                            AccountingCode.class).getResultList();
-            return accountingCodes;
-        } catch (Exception e) {
-            System.out.println(e);
-            return new ArrayList<>();
-        }
-    }
 
     @Override
     public Long getId() {
@@ -279,84 +337,24 @@ public class AccountingCode implements Serializable, BusinessEntity {
         this.isDirty = isDirty;
     }
 
-    public static AccountingCode findByName(EntityManager em, String value) {
-
-        try {
-
-            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
-
-            List<AccountingCode> accountingCodes = em.createQuery("SELECT a FROM AccountingCode a "
-                    + "WHERE UPPER(a.name) "
-                    + "= '" + value.toUpperCase() + "'", AccountingCode.class).getResultList();
-
-            if (!accountingCodes.isEmpty()) {
-                return accountingCodes.get(0);
-            }
-
-            return null;
-        } catch (Exception e) {
-            System.out.println(e);
-            return null;
-        }
-    }
-
-    public static AccountingCode findByCode(EntityManager em, String value) {
-
-        try {
-
-            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
-
-            List<AccountingCode> accountingCodes = em.createQuery("SELECT a FROM AccountingCode a "
-                    + "WHERE UPPER(a.code) "
-                    + "= '" + value.toUpperCase() + "'", AccountingCode.class).getResultList();
-            if (!accountingCodes.isEmpty()) {
-                return accountingCodes.get(0);
-            }
-
-            return null;
-        } catch (Exception e) {
-            System.out.println(e);
-
-            return null;
-        }
-    }
-
-    public static AccountingCode findActiveByCode(EntityManager em, String value) {
-
-        try {
-
-            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
-
-            List<AccountingCode> accountingCodes = em.createQuery("SELECT a FROM AccountingCode a "
-                    + "WHERE UPPER(a.code) "
-                    + "= '" + value.toUpperCase() + "' AND (a.active = 1 OR a.active IS NULL)", AccountingCode.class).getResultList();
-            if (!accountingCodes.isEmpty()) {
-                return accountingCodes.get(0);
-            }
-            return null;
-        } catch (Exception e) {
-            System.out.println(e);
-            return null;
-        }
-    }
 
     @Override
-    public Date getDateEntered() {
+    public LocalDateTime getDateEntered() {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public void setDateEntered(Date dateEntered) {
+    public void setDateEntered(LocalDateTime dateEntered) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public Date getDateEdited() {
+    public LocalDateTime getDateEdited() {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public void setDateEdited(Date dateEdited) {
+    public void setDateEdited(LocalDateTime dateEdited) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 

--- a/src/main/java/jm/com/dpbennett/business/entity/fm/CashPayment.java
+++ b/src/main/java/jm/com/dpbennett/business/entity/fm/CashPayment.java
@@ -19,20 +19,20 @@ Email: info@dpbennett.com.jm
  */
 package jm.com.dpbennett.business.entity.fm;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import java.io.Serializable;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import javax.persistence.Entity;
-import javax.persistence.EntityManager;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.NamedQueries;
-import javax.persistence.NamedQuery;
-import javax.persistence.Table;
-import javax.persistence.Temporal;
-import javax.persistence.Transient;
 import jm.com.dpbennett.business.entity.BusinessEntity;
 import jm.com.dpbennett.business.entity.Person;
 import jm.com.dpbennett.business.entity.sm.SystemOption;
@@ -51,6 +51,47 @@ import jm.com.dpbennett.business.entity.util.ReturnMessage;
 })
 public class CashPayment implements Serializable, Comparable, BusinessEntity {
 
+    private static final long serialVersionUID = 1L;
+    private static final System.Logger LOG = System.getLogger(CashPayment.class.getName());
+    
+    public static CashPayment copy(CashPayment src) {
+        CashPayment copy = new CashPayment();
+        
+        copy.type = src.type;
+        copy.jobId = src.jobId;
+        copy.payment = src.payment;
+        copy.receiptNumber = src.receiptNumber;
+        copy.invoiceNumber = src.invoiceNumber;
+        copy.dateOfPayment = src.dateOfPayment;
+        copy.payeeTitle = src.payeeTitle;
+        copy.payeeFirstname = src.payeeFirstname;
+        copy.payeeLastname = src.payeeLastname;
+        copy.comment = src.comment;
+        copy.userId = src.userId;
+        copy.discount = src.discount;
+        copy.discountType = src.discountType;
+        copy.paymentTerms = src.paymentTerms;
+        copy.paymentPurpose = src.paymentPurpose;
+        
+        return copy;
+    }
+    public static List<CashPayment> findCashPaymentsByOwnerId(EntityManager em, Long ownerId) {
+        
+        try {
+            
+            List<CashPayment> cashPayments
+                    = em.createQuery("SELECT c FROM CashPayment c WHERE"
+                            + " c.ownerId = " + ownerId
+                            + " ORDER BY c.id DESC",
+                            CashPayment.class).getResultList();
+            
+            return cashPayments;
+        } catch (Exception e) {
+            System.out.println(e);
+            return new ArrayList<>();
+        }
+    }
+
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
@@ -59,7 +100,6 @@ public class CashPayment implements Serializable, Comparable, BusinessEntity {
     private Double payment;
     private String receiptNumber;
     private String invoiceNumber;
-    @Temporal(javax.persistence.TemporalType.DATE)
     private Date dateOfPayment;
     private String payeeTitle;
     private String payeeFirstname;
@@ -124,44 +164,6 @@ public class CashPayment implements Serializable, Comparable, BusinessEntity {
         this.id = id;
     }
 
-    public static CashPayment copy(CashPayment src) {
-        CashPayment copy = new CashPayment();
-
-        copy.type = src.type;
-        copy.jobId = src.jobId;
-        copy.payment = src.payment;
-        copy.receiptNumber = src.receiptNumber;
-        copy.invoiceNumber = src.invoiceNumber;
-        copy.dateOfPayment = src.dateOfPayment;
-        copy.payeeTitle = src.payeeTitle;
-        copy.payeeFirstname = src.payeeFirstname;
-        copy.payeeLastname = src.payeeLastname;
-        copy.comment = src.comment;
-        copy.userId = src.userId;
-        copy.discount = src.discount;
-        copy.discountType = src.discountType;
-        copy.paymentTerms = src.paymentTerms;
-        copy.paymentPurpose = src.paymentPurpose;
-
-        return copy;
-    }
-
-    public static List<CashPayment> findCashPaymentsByOwnerId(EntityManager em, Long ownerId) {
-
-        try {
-
-            List<CashPayment> cashPayments
-                    = em.createQuery("SELECT c FROM CashPayment c WHERE"
-                            + " c.ownerId = " + ownerId
-                            + " ORDER BY c.id DESC",
-                            CashPayment.class).getResultList();
-
-            return cashPayments;
-        } catch (Exception e) {
-            System.out.println(e);
-            return new ArrayList<>();
-        }
-    }
 
     public Long getOwnerId() {
         return ownerId;
@@ -412,22 +414,22 @@ public class CashPayment implements Serializable, Comparable, BusinessEntity {
     }
 
     @Override
-    public Date getDateEntered() {
+    public LocalDateTime getDateEntered() {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public void setDateEntered(Date dateEntered) {
+    public void setDateEntered(LocalDateTime dateEntered) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public Date getDateEdited() {
+    public LocalDateTime getDateEdited() {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public void setDateEdited(Date dateEdited) {
+    public void setDateEdited(LocalDateTime dateEdited) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 

--- a/src/main/java/jm/com/dpbennett/business/entity/fm/Classification.java
+++ b/src/main/java/jm/com/dpbennett/business/entity/fm/Classification.java
@@ -19,22 +19,22 @@ Email: info@dpbennett.com.jm
  */
 package jm.com.dpbennett.business.entity.fm;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import java.io.Serializable;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EntityManager;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.NamedQueries;
-import javax.persistence.NamedQuery;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
-import javax.persistence.Transient;
 import jm.com.dpbennett.business.entity.BusinessEntity;
 import jm.com.dpbennett.business.entity.Person;
 import jm.com.dpbennett.business.entity.sm.SystemOption;
@@ -54,6 +54,138 @@ import jm.com.dpbennett.business.entity.util.ReturnMessage;
 public class Classification implements BusinessEntity, Serializable {
 
     private static final long serialVersionUID = 1L;
+    private static final System.Logger LOG = System.getLogger(Classification.class.getName());
+    
+    public static List<Classification> findAllClassifications(EntityManager em) {
+        
+        try {
+            List<Classification> classfications = em.createNamedQuery("findAllClassifications", Classification.class).getResultList();
+            
+            return classfications;
+        } catch (Exception e) {
+            
+            return null;
+        }
+        
+    }
+    public static List<Classification> findAllActiveClassifications(EntityManager em) {
+        
+        try {
+            List<Classification> classfications = em.createNamedQuery("findAllActiveClassifications", Classification.class).getResultList();
+            
+            return classfications;
+        } catch (Exception e) {
+            return null;
+        }
+        
+    }
+    public static Classification findClassificationById(EntityManager em, Long id) {
+        
+        try {
+            Classification classification = em.find(Classification.class, id);
+            
+            return classification;
+        } catch (Exception e) {
+            
+            return null;
+        }
+    }
+    public static Classification findClassificationByName(EntityManager em, String value) {
+        
+        try {
+            
+            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
+            
+            List<Classification> classifications = em.createQuery("SELECT c FROM Classification c "
+                    + "WHERE UPPER(c.name) "
+                    + "= '" + value.toUpperCase() + "'", Classification.class).getResultList();
+            if (!classifications.isEmpty()) {
+                return classifications.get(0);
+            }
+            return null;
+        } catch (Exception e) {
+            System.out.println(e);
+            return null;
+        }
+        
+    }
+    public static List<Classification> findClassificationsByName(EntityManager em, String value) {
+        
+        try {
+            
+            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
+            
+            List<Classification> classifications
+                    = em.createQuery("SELECT c FROM Classification c where UPPER(c.name) like '%"
+                            + value.toUpperCase().trim() + "%' ORDER BY c.name", Classification.class).getResultList();
+            return classifications;
+        } catch (Exception e) {
+            System.out.println(e);
+            return new ArrayList<>();
+        }
+    }
+    public static List<Classification> findClassificationsByNameAndCategory(EntityManager em, String value, String category) {
+        
+        try {
+            
+            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
+            category = category.replaceAll("&amp;", "&").replaceAll("'", "`");
+            
+            List<Classification> classifications
+                    = em.createQuery("SELECT c FROM Classification c where UPPER(c.name) like '%"
+                            + value.toUpperCase().trim() + "%' AND c.category = " + category + " ORDER BY c.name", Classification.class).getResultList();
+            return classifications;
+        } catch (Exception e) {
+            System.out.println(e);
+            return new ArrayList<>();
+        }
+    }
+    public static List<Classification> findActiveClassificationsByName(EntityManager em, String value) {
+        
+        try {
+            
+            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
+            
+            List<Classification> classifications
+                    = em.createQuery("SELECT c FROM Classification c where UPPER(c.name) like '%"
+                            + value.toUpperCase().trim() + "%' AND c.active = 1 ORDER BY c.name", Classification.class).getResultList();
+            return classifications;
+        } catch (Exception e) {
+            System.out.println(e);
+            return new ArrayList<>();
+        }
+    }
+    public static List<Classification> findActiveClassificationsByNameAndCategory(EntityManager em, String value, String category) {
+        
+        try {
+            
+            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
+            category = category.replaceAll("&amp;", "&").replaceAll("'", "`");
+            
+            List<Classification> classifications
+                    = em.createQuery("SELECT c FROM Classification c where UPPER(c.name) like '"
+                            + value.toUpperCase().trim() + "%' AND c.active = 1 AND c.category = '" + category + "' ORDER BY c.name", Classification.class).getResultList();
+            return classifications;
+        } catch (Exception e) {
+            System.out.println(e);
+            return new ArrayList<>();
+        }
+    }
+    public static List<Classification> findActiveClassificationsByCategory(EntityManager em, String category) {
+        
+        try {
+            
+            category = category.replaceAll("&amp;", "&").replaceAll("'", "`");
+            
+            List<Classification> classifications
+                    = em.createQuery("SELECT c FROM Classification c WHERE "
+                            + "c.active = 1 AND c.category = '" + category + "' ORDER BY c.name", Classification.class).getResultList();
+            return classifications;
+        } catch (Exception e) {
+            System.out.println(e);
+            return new ArrayList<>();
+        }
+    }
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
@@ -228,144 +360,6 @@ public class Classification implements BusinessEntity, Serializable {
         return name;
     }
 
-    public static List<Classification> findAllClassifications(EntityManager em) {
-
-        try {
-            List<Classification> classfications = em.createNamedQuery("findAllClassifications", Classification.class).getResultList();
-
-            return classfications;
-        } catch (Exception e) {
-
-            return null;
-        }
-
-    }
-
-    public static List<Classification> findAllActiveClassifications(EntityManager em) {
-
-        try {
-            List<Classification> classfications = em.createNamedQuery("findAllActiveClassifications", Classification.class).getResultList();
-
-            return classfications;
-        } catch (Exception e) {
-            return null;
-        }
-
-    }
-
-    public static Classification findClassificationById(EntityManager em, Long id) {
-
-        try {
-            Classification classification = em.find(Classification.class, id);
-
-            return classification;
-        } catch (Exception e) {
-
-            return null;
-        }
-    }
-
-    public static Classification findClassificationByName(EntityManager em, String value) {
-
-        try {
-
-            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
-
-            List<Classification> classifications = em.createQuery("SELECT c FROM Classification c "
-                    + "WHERE UPPER(c.name) "
-                    + "= '" + value.toUpperCase() + "'", Classification.class).getResultList();
-            if (!classifications.isEmpty()) {
-                return classifications.get(0);
-            }
-            return null;
-        } catch (Exception e) {
-            System.out.println(e);
-            return null;
-        }
-
-    }
-
-    public static List<Classification> findClassificationsByName(EntityManager em, String value) {
-
-        try {
-
-            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
-
-            List<Classification> classifications
-                    = em.createQuery("SELECT c FROM Classification c where UPPER(c.name) like '%"
-                            + value.toUpperCase().trim() + "%' ORDER BY c.name", Classification.class).getResultList();
-            return classifications;
-        } catch (Exception e) {
-            System.out.println(e);
-            return new ArrayList<>();
-        }
-    }
-
-    public static List<Classification> findClassificationsByNameAndCategory(EntityManager em, String value, String category) {
-
-        try {
-
-            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
-            category = category.replaceAll("&amp;", "&").replaceAll("'", "`");
-
-            List<Classification> classifications
-                    = em.createQuery("SELECT c FROM Classification c where UPPER(c.name) like '%"
-                            + value.toUpperCase().trim() + "%' AND c.category = " + category + " ORDER BY c.name", Classification.class).getResultList();
-            return classifications;
-        } catch (Exception e) {
-            System.out.println(e);
-            return new ArrayList<>();
-        }
-    }
-
-    public static List<Classification> findActiveClassificationsByName(EntityManager em, String value) {
-
-        try {
-
-            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
-
-            List<Classification> classifications
-                    = em.createQuery("SELECT c FROM Classification c where UPPER(c.name) like '%"
-                            + value.toUpperCase().trim() + "%' AND c.active = 1 ORDER BY c.name", Classification.class).getResultList();
-            return classifications;
-        } catch (Exception e) {
-            System.out.println(e);
-            return new ArrayList<>();
-        }
-    }
-
-    public static List<Classification> findActiveClassificationsByNameAndCategory(EntityManager em, String value, String category) {
-
-        try {
-
-            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
-            category = category.replaceAll("&amp;", "&").replaceAll("'", "`");
-
-            List<Classification> classifications
-                    = em.createQuery("SELECT c FROM Classification c where UPPER(c.name) like '"
-                            + value.toUpperCase().trim() + "%' AND c.active = 1 AND c.category = '" + category + "' ORDER BY c.name", Classification.class).getResultList();
-            return classifications;
-        } catch (Exception e) {
-            System.out.println(e);
-            return new ArrayList<>();
-        }
-    }
-
-    public static List<Classification> findActiveClassificationsByCategory(EntityManager em, String category) {
-
-        try {
-
-            category = category.replaceAll("&amp;", "&").replaceAll("'", "`");
-
-            List<Classification> classifications
-                    = em.createQuery("SELECT c FROM Classification c WHERE "
-                            + "c.active = 1 AND c.category = '" + category + "' ORDER BY c.name", Classification.class).getResultList();
-            return classifications;
-        } catch (Exception e) {
-            System.out.println(e);
-            return new ArrayList<>();
-        }
-    }
 
     @Override
     public ReturnMessage save(EntityManager em) {
@@ -413,22 +407,22 @@ public class Classification implements BusinessEntity, Serializable {
     }
 
     @Override
-    public Date getDateEntered() {
+    public LocalDateTime getDateEntered() {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public void setDateEntered(Date dateEntered) {
+    public void setDateEntered(LocalDateTime dateEntered) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public Date getDateEdited() {
+    public LocalDateTime getDateEdited() {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public void setDateEdited(Date dateEdited) {
+    public void setDateEdited(LocalDateTime dateEdited) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 

--- a/src/main/java/jm/com/dpbennett/business/entity/fm/CostCode.java
+++ b/src/main/java/jm/com/dpbennett/business/entity/fm/CostCode.java
@@ -20,18 +20,19 @@ Email: info@dpbennett.com.jm
 
 package jm.com.dpbennett.business.entity.fm;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import java.io.Serializable;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EntityManager;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Table;
-import javax.persistence.Transient;
 import jm.com.dpbennett.business.entity.BusinessEntity;
 import jm.com.dpbennett.business.entity.Person;
 import jm.com.dpbennett.business.entity.sm.SystemOption;
@@ -46,6 +47,49 @@ import jm.com.dpbennett.business.entity.util.ReturnMessage;
 public class CostCode implements BusinessEntity, Serializable {
 
     private static final long serialVersionUID = 1L;
+    private static final System.Logger LOG = System.getLogger(CostCode.class.getName());
+    public static CostCode findCostCodeByCode(EntityManager em, String code) {
+        
+        try {
+            
+            code = code.replaceAll("&amp;", "&").replaceAll("'", "`");
+            
+            List<CostCode> codes = em.createQuery("SELECT c FROM CostCode c "
+                    + "WHERE c.code "
+                    + "= '" + code + "'", CostCode.class).getResultList();
+            if (!codes.isEmpty()) {
+                return codes.get(0);
+            }
+            return null;
+        } catch (Exception e) {
+            System.out.println(e);
+            return null;
+        }
+        
+    }
+    public static List<CostCode> findAllCostCodes(EntityManager em) {
+        
+        try {
+            List<CostCode> codes = em.createQuery("SELECT c FROM CostCode c ORDER BY c.code", CostCode.class).getResultList();
+            
+            return codes;
+        } catch (Exception e) {
+            System.out.println(e);
+            return new ArrayList<>();
+        }
+    }
+    public static CostCode findCostCodeById(EntityManager em, Long id) {
+        
+        try {
+            
+            CostCode code = em.find(CostCode.class, id);
+            
+            return code;
+        } catch (Exception e) {
+            System.out.println(e);
+            return null;
+        }
+    }
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
@@ -135,50 +179,6 @@ public class CostCode implements BusinessEntity, Serializable {
         this.name = name;
     }
 
-    public static CostCode findCostCodeByCode(EntityManager em, String code) {
-
-        try {
-
-            code = code.replaceAll("&amp;", "&").replaceAll("'", "`");
-
-            List<CostCode> codes = em.createQuery("SELECT c FROM CostCode c "
-                    + "WHERE c.code "
-                    + "= '" + code + "'", CostCode.class).getResultList();
-            if (!codes.isEmpty()) {
-                return codes.get(0);
-            }
-            return null;
-        } catch (Exception e) {
-            System.out.println(e);
-            return null;
-        }
-
-    }
-
-    public static List<CostCode> findAllCostCodes(EntityManager em) {
-
-        try {
-            List<CostCode> codes = em.createQuery("SELECT c FROM CostCode c ORDER BY c.code", CostCode.class).getResultList();
-
-            return codes;
-        } catch (Exception e) {
-            System.out.println(e);
-            return new ArrayList<>();
-        }
-    }
-
-    public static CostCode findCostCodeById(EntityManager em, Long id) {
-
-        try {
-
-            CostCode code = em.find(CostCode.class, id);
-
-            return code;
-        } catch (Exception e) {
-            System.out.println(e);
-            return null;
-        }
-    }
 
     @Override
     public ReturnMessage save(EntityManager em) {
@@ -225,22 +225,22 @@ public class CostCode implements BusinessEntity, Serializable {
     }
 
     @Override
-    public Date getDateEntered() {
+    public LocalDateTime getDateEntered() {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public void setDateEntered(Date dateEntered) {
+    public void setDateEntered(LocalDateTime dateEntered) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public Date getDateEdited() {
+    public LocalDateTime getDateEdited() {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public void setDateEdited(Date dateEdited) {
+    public void setDateEdited(LocalDateTime dateEdited) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 

--- a/src/main/java/jm/com/dpbennett/business/entity/fm/CostComponent.java
+++ b/src/main/java/jm/com/dpbennett/business/entity/fm/CostComponent.java
@@ -19,25 +19,25 @@ Email: info@dpbennett.com.jm
  */
 package jm.com.dpbennett.business.entity.fm;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Query;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import java.io.Serializable;
 import java.text.Collator;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EntityManager;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.NamedQueries;
-import javax.persistence.NamedQuery;
-import javax.persistence.OneToOne;
-import javax.persistence.Query;
-import javax.persistence.Table;
-import javax.persistence.Temporal;
-import javax.persistence.Transient;
 import jm.com.dpbennett.business.entity.BusinessEntity;
 import jm.com.dpbennett.business.entity.Person;
 import jm.com.dpbennett.business.entity.sm.SystemOption;
@@ -57,6 +57,56 @@ import jm.com.dpbennett.business.entity.util.ReturnMessage;
 public class CostComponent implements BusinessEntity, Serializable, Comparable {
 
     private static final long serialVersionUID = 1L;
+    private static final System.Logger LOG = System.getLogger(CostComponent.class.getName());
+    
+    public static CostComponent copy(CostComponent src) {
+        CostComponent copy = new CostComponent();
+        
+        copy.name = src.name;
+        copy.code = src.code;
+        copy.type = src.type;
+        copy.category = src.category;
+        copy.hours = src.hours;
+        copy.hoursOrQuantity = src.hoursOrQuantity;
+        copy.rate = src.rate;
+        copy.convertedRate = src.convertedRate;
+        copy.cost = src.cost;
+        copy.convertedCost = src.convertedCost;
+        copy.comments = src.comments;
+        copy.isHeading = src.isHeading;
+        copy.isFixedCost = src.isFixedCost;
+        copy.isEditable = src.isEditable;
+        copy.description = src.description;
+        copy.unit = src.unit;
+        copy.currency = src.currency;
+        copy.costDate = src.costDate;
+        copy.currencyExchangeRate = src.currencyExchangeRate;
+        
+        return copy;
+    }
+    public static List<CostComponent> findCostComponentsByName(String name, List<CostComponent> list) {
+        ArrayList<CostComponent> foundComponents = new ArrayList<>();
+        
+        for (CostComponent costComponent : list) {
+            if (costComponent.getName().equals(name)) {
+                foundComponents.add(costComponent);
+            }
+        }
+        
+        return foundComponents;
+    }
+    public static CostComponent findByOwnerId(EntityManager em, Long ownerId) {
+        try {
+            Query q = em.createNamedQuery("findByJobId");
+            q.setParameter("jobId", ownerId);
+            
+            return (CostComponent) q.getSingleResult();
+            
+        } catch (Exception e) {
+            
+            return null;
+        }
+    }
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
@@ -80,7 +130,6 @@ public class CostComponent implements BusinessEntity, Serializable, Comparable {
     private String unit;
     @OneToOne(cascade = CascadeType.REFRESH)
     private Currency currency;
-    @Temporal(javax.persistence.TemporalType.DATE)
     private Date costDate;
     private Double currencyExchangeRate;
     @Transient
@@ -350,31 +399,6 @@ public class CostComponent implements BusinessEntity, Serializable, Comparable {
         this.currencyExchangeRate = src.currencyExchangeRate;
     }
 
-    public static CostComponent copy(CostComponent src) {
-        CostComponent copy = new CostComponent();
-
-        copy.name = src.name;
-        copy.code = src.code;
-        copy.type = src.type;
-        copy.category = src.category;
-        copy.hours = src.hours;
-        copy.hoursOrQuantity = src.hoursOrQuantity;
-        copy.rate = src.rate;
-        copy.convertedRate = src.convertedRate;
-        copy.cost = src.cost;
-        copy.convertedCost = src.convertedCost;
-        copy.comments = src.comments;
-        copy.isHeading = src.isHeading;
-        copy.isFixedCost = src.isFixedCost;
-        copy.isEditable = src.isEditable;
-        copy.description = src.description;
-        copy.unit = src.unit;
-        copy.currency = src.currency;
-        copy.costDate = src.costDate;
-        copy.currencyExchangeRate = src.currencyExchangeRate;
-
-        return copy;
-    }
 
     public Boolean getIsSubcontract() {
         return getType().toUpperCase().equals("SUBCONTRACT");
@@ -542,30 +566,6 @@ public class CostComponent implements BusinessEntity, Serializable, Comparable {
         return Collator.getInstance().compare(this.toString(), ((CostComponent) o).toString());
     }
 
-    public static List<CostComponent> findCostComponentsByName(String name, List<CostComponent> list) {
-        ArrayList<CostComponent> foundComponents = new ArrayList<>();
-
-        for (CostComponent costComponent : list) {
-            if (costComponent.getName().equals(name)) {
-                foundComponents.add(costComponent);
-            }
-        }
-
-        return foundComponents;
-    }
-
-    public static CostComponent findByOwnerId(EntityManager em, Long ownerId) {
-        try {
-            Query q = em.createNamedQuery("findByJobId");
-            q.setParameter("jobId", ownerId);
-
-            return (CostComponent) q.getSingleResult();
-
-        } catch (Exception e) {
-
-            return null;
-        }
-    }
 
     @Override
     public ReturnMessage save(EntityManager em) {
@@ -607,22 +607,22 @@ public class CostComponent implements BusinessEntity, Serializable, Comparable {
     }
 
     @Override
-    public Date getDateEntered() {
+    public LocalDateTime getDateEntered() {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public void setDateEntered(Date dateEntered) {
+    public void setDateEntered(LocalDateTime dateEntered) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public Date getDateEdited() {
+    public LocalDateTime getDateEdited() {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public void setDateEdited(Date dateEdited) {
+    public void setDateEdited(LocalDateTime dateEdited) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 

--- a/src/main/java/jm/com/dpbennett/business/entity/fm/Currency.java
+++ b/src/main/java/jm/com/dpbennett/business/entity/fm/Currency.java
@@ -19,20 +19,20 @@ Email: info@dpbennett.com.jm
  */
 package jm.com.dpbennett.business.entity.fm;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import javax.persistence.Entity;
-import javax.persistence.EntityManager;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Table;
-import javax.persistence.Transient;
 import jm.com.dpbennett.business.entity.util.BusinessEntityUtils;
 import jm.com.dpbennett.business.entity.util.ReturnMessage;
 import java.text.Collator;
-import java.util.Date;
+import java.time.LocalDateTime;
 import jm.com.dpbennett.business.entity.BusinessEntity;
 import jm.com.dpbennett.business.entity.Person;
 import jm.com.dpbennett.business.entity.cm.Client;
@@ -47,6 +47,87 @@ import jm.com.dpbennett.business.entity.sm.SystemOption;
 public class Currency implements Asset, BusinessEntity, Serializable, Comparable {
 
     private static final long serialVersionUID = 1L;
+    private static final System.Logger LOG = System.getLogger(Currency.class.getName());
+    
+    public static Currency findByName(EntityManager em, String value) {
+        
+        try {
+            
+            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
+            
+            List<Currency> currencies = em.createQuery("SELECT c FROM Currency c "
+                    + "WHERE UPPER(c.name) "
+                    + "= '" + value.toUpperCase() + "'", Currency.class).getResultList();
+            if (!currencies.isEmpty()) {
+                return currencies.get(0);
+            }
+            
+            return null;
+        } catch (Exception e) {
+            System.out.println(e);
+            return null;
+        }
+        
+    }
+    public static Currency findByCode(EntityManager em, String code) {
+        
+        try {
+            
+            code = code.replaceAll("&amp;", "&").replaceAll("'", "`");
+            
+            List<Currency> currencies = em.createQuery("SELECT c FROM Currency c "
+                    + "WHERE c.code "
+                    + "= '" + code + "'", Currency.class).getResultList();
+            if (!currencies.isEmpty()) {
+                return currencies.get(0);
+            }
+            return null;
+        } catch (Exception e) {
+            System.out.println(e);
+            return null;
+        }
+        
+    }
+    public static List<Currency> findAll(EntityManager em) {
+        
+        try {
+            
+            List<Currency> codes = em.createQuery("SELECT c FROM Currency c ORDER BY c.code", Currency.class).getResultList();
+            
+            return codes;
+        } catch (Exception e) {
+            System.out.println(e);
+            return new ArrayList<>();
+        }
+    }
+    public static List<Currency> findAllByName(EntityManager em, String value) {
+        
+        try {
+            
+            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
+            
+            List<Currency> currencies
+                    = em.createQuery("SELECT c FROM Currency c WHERE UPPER(c.name) LIKE '%"
+                            + value.toUpperCase().trim() + "%' ORDER BY c.name",
+                            Currency.class).getResultList();
+            return currencies;
+        } catch (Exception e) {
+            System.out.println(e);
+            return new ArrayList<>();
+        }
+    }
+    public static Currency findById(EntityManager em, Long id) {
+        
+        try {
+            
+            Currency code = em.find(Currency.class, id);
+            
+            return code;
+        } catch (Exception e) {
+            System.out.println(e);
+            return null;
+        }
+    }
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
@@ -141,89 +222,6 @@ public class Currency implements Asset, BusinessEntity, Serializable, Comparable
         this.name = name;
     }
 
-    public static Currency findByName(EntityManager em, String value) {
-
-        try {
-
-            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
-
-            List<Currency> currencies = em.createQuery("SELECT c FROM Currency c "
-                    + "WHERE UPPER(c.name) "
-                    + "= '" + value.toUpperCase() + "'", Currency.class).getResultList();
-            if (!currencies.isEmpty()) {
-                return currencies.get(0);
-            }
-
-            return null;
-        } catch (Exception e) {
-            System.out.println(e);
-            return null;
-        }
-
-    }
-
-    public static Currency findByCode(EntityManager em, String code) {
-
-        try {
-
-            code = code.replaceAll("&amp;", "&").replaceAll("'", "`");
-
-            List<Currency> currencies = em.createQuery("SELECT c FROM Currency c "
-                    + "WHERE c.code "
-                    + "= '" + code + "'", Currency.class).getResultList();
-            if (!currencies.isEmpty()) {
-                return currencies.get(0);
-            }
-            return null;
-        } catch (Exception e) {
-            System.out.println(e);
-            return null;
-        }
-
-    }
-
-    public static List<Currency> findAll(EntityManager em) {
-
-        try {
-
-            List<Currency> codes = em.createQuery("SELECT c FROM Currency c ORDER BY c.code", Currency.class).getResultList();
-
-            return codes;
-        } catch (Exception e) {
-            System.out.println(e);
-            return new ArrayList<>();
-        }
-    }
-
-    public static List<Currency> findAllByName(EntityManager em, String value) {
-
-        try {
-
-            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
-
-            List<Currency> currencies
-                    = em.createQuery("SELECT c FROM Currency c WHERE UPPER(c.name) LIKE '%"
-                            + value.toUpperCase().trim() + "%' ORDER BY c.name",
-                            Currency.class).getResultList();
-            return currencies;
-        } catch (Exception e) {
-            System.out.println(e);
-            return new ArrayList<>();
-        }
-    }
-
-    public static Currency findById(EntityManager em, Long id) {
-
-        try {
-
-            Currency code = em.find(Currency.class, id);
-
-            return code;
-        } catch (Exception e) {
-            System.out.println(e);
-            return null;
-        }
-    }
 
     @Override
     public ReturnMessage save(EntityManager em) {
@@ -286,22 +284,22 @@ public class Currency implements Asset, BusinessEntity, Serializable, Comparable
     }
 
     @Override
-    public Date getDateEntered() {
+    public LocalDateTime getDateEntered() {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public void setDateEntered(Date dateEntered) {
+    public void setDateEntered(LocalDateTime dateEntered) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public Date getDateEdited() {
+    public LocalDateTime getDateEdited() {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public void setDateEdited(Date dateEdited) {
+    public void setDateEdited(LocalDateTime dateEdited) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 

--- a/src/main/java/jm/com/dpbennett/business/entity/fm/Discount.java
+++ b/src/main/java/jm/com/dpbennett/business/entity/fm/Discount.java
@@ -19,22 +19,22 @@ Email: info@dpbennett.com.jm
  */
 package jm.com.dpbennett.business.entity.fm;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import java.io.Serializable;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EntityManager;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.NamedQueries;
-import javax.persistence.NamedQuery;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
-import javax.persistence.Transient;
 import jm.com.dpbennett.business.entity.BusinessEntity;
 import jm.com.dpbennett.business.entity.Person;
 import jm.com.dpbennett.business.entity.sm.SystemOption;
@@ -54,6 +54,154 @@ import jm.com.dpbennett.business.entity.util.ReturnMessage;
 public class Discount implements Serializable, BusinessEntity {
 
     private static final long serialVersionUID = 1L;
+    private static final System.Logger LOG = System.getLogger(Discount.class.getName());
+    
+    public static Discount findDefault(EntityManager em, String name) {
+        Discount discount = Discount.findByName(em, name);
+        
+        name = name.replaceAll("&amp;", "&").replaceAll("'", "`");
+        
+        if (discount == null) {
+            discount = new Discount(name);
+            
+            em.getTransaction().begin();
+            BusinessEntityUtils.saveBusinessEntity(em, discount);
+            em.getTransaction().commit();
+        }
+        
+        return discount;
+    }
+    public static Discount findDefault(EntityManager em,
+            String name, Double value, String type) {
+        Discount discount = Discount.findByName(em, name);
+        
+        name = name.replaceAll("&amp;", "&").replaceAll("'", "`");
+        type = type.replaceAll("&amp;", "&").replaceAll("'", "`");
+        
+        if (discount == null) {
+            discount = new Discount(name, value, type);
+            discount.setActive(false);
+            
+            em.getTransaction().begin();
+            BusinessEntityUtils.saveBusinessEntity(em, discount);
+            em.getTransaction().commit();
+        }
+        
+        return discount;
+    }
+    public static List<Discount> findAllDiscounts(EntityManager em) {
+        
+        try {
+            
+            List<Discount> discounts = em.createNamedQuery("findAllDiscounts", Discount.class).getResultList();
+            
+            return discounts;
+            
+        } catch (Exception e) {
+            System.out.println(e);
+            return null;
+        }
+    }
+    public static List<Discount> findAllActiveDiscounts(EntityManager em) {
+        
+        try {
+            
+            List<Discount> discounts = em.createNamedQuery("findAllActiveDiscounts", Discount.class).getResultList();
+            
+            return discounts;
+            
+        } catch (Exception e) {
+            System.out.println(e);
+            return null;
+        }
+    }
+    public static List<Discount> findDiscountsByNameAndDescription(EntityManager em, String value) {
+        
+        try {
+            
+            value = value.replaceAll("'", "`");
+            
+            List<Discount> discounts
+                    = em.createQuery("SELECT d FROM Discount d WHERE UPPER(d.name) LIKE '%"
+                            + value.toUpperCase().trim() + "%' OR UPPER(d.description) LIKE '%"
+                            + value.toUpperCase().trim() + "%' ORDER BY d.name",
+                            Discount.class).getResultList();
+            return discounts;
+        } catch (Exception e) {
+            System.out.println(e);
+            return new ArrayList<>();
+        }
+    }
+    public static List<Discount> findActiveDiscountsByNameAndDescription(EntityManager em, String value) {
+        
+        try {
+            
+            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
+            
+            List<Discount> discounts
+                    = em.createQuery("SELECT d FROM Discount d WHERE (UPPER(d.name) LIKE '%"
+                            + value.toUpperCase().trim() + "%' OR UPPER(d.description) LIKE '%"
+                            + value.toUpperCase().trim() + "%') AND d.active = 1 ORDER BY d.name",
+                            Discount.class).getResultList();
+            return discounts;
+        } catch (Exception e) {
+            System.out.println(e);
+            return new ArrayList<>();
+        }
+    }
+    public static Discount findByName(EntityManager em, String value) {
+        
+        try {
+            
+            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
+            
+            List<Discount> discounts = em.createQuery("SELECT d FROM Discount d "
+                    + "WHERE UPPER(d.name) "
+                    + "= '" + value.toUpperCase() + "'", Discount.class).getResultList();
+            if (!discounts.isEmpty()) {
+                return discounts.get(0);
+            }
+            return null;
+        } catch (Exception e) {
+            System.out.println(e);
+            return null;
+        }
+    }
+    public static Discount findByValue(EntityManager em, Double value) {
+        
+        try {
+            
+            List<Discount> discounts = em.createQuery("SELECT d FROM Discount d"
+                    + " WHERE d.discountValue = " + value, Discount.class).getResultList();
+            if (!discounts.isEmpty()) {
+                return discounts.get(0);
+            }
+            return null;
+        } catch (Exception e) {
+            System.out.println(e);
+            return null;
+        }
+    }
+    public static Discount findByValueAndType(EntityManager em,
+            Double value,
+            String valueType) {
+        
+        try {
+            
+            valueType = valueType.replaceAll("&amp;", "&").replaceAll("'", "`");
+            
+            List<Discount> discounts = em.createQuery("SELECT d FROM Discount d"
+                    + " WHERE d.discountValue = " + value
+                    + " AND d.discountValueType LIKE '" + valueType + "'", Discount.class).getResultList();
+            if (!discounts.isEmpty()) {
+                return discounts.get(0);
+            }
+            return null;
+        } catch (Exception e) {
+            System.out.println(e);
+            return null;
+        }
+    }
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
@@ -110,40 +258,6 @@ public class Discount implements Serializable, BusinessEntity {
         this.active = active;
     }
 
-    public static Discount findDefault(EntityManager em, String name) {
-        Discount discount = Discount.findByName(em, name);
-
-        name = name.replaceAll("&amp;", "&").replaceAll("'", "`");
-
-        if (discount == null) {
-            discount = new Discount(name);
-
-            em.getTransaction().begin();
-            BusinessEntityUtils.saveBusinessEntity(em, discount);
-            em.getTransaction().commit();
-        }
-
-        return discount;
-    }
-
-    public static Discount findDefault(EntityManager em,
-            String name, Double value, String type) {
-        Discount discount = Discount.findByName(em, name);
-
-        name = name.replaceAll("&amp;", "&").replaceAll("'", "`");
-        type = type.replaceAll("&amp;", "&").replaceAll("'", "`");
-
-        if (discount == null) {
-            discount = new Discount(name, value, type);
-            discount.setActive(false);
-
-            em.getTransaction().begin();
-            BusinessEntityUtils.saveBusinessEntity(em, discount);
-            em.getTransaction().commit();
-        }
-
-        return discount;
-    }
 
     public Double getValue() {
         if (discountValueType.equals("Percentage")) {
@@ -192,69 +306,6 @@ public class Discount implements Serializable, BusinessEntity {
         this.accountingCode = accountingCode;
     }
 
-    public static List<Discount> findAllDiscounts(EntityManager em) {
-
-        try {
-
-            List<Discount> discounts = em.createNamedQuery("findAllDiscounts", Discount.class).getResultList();
-
-            return discounts;
-
-        } catch (Exception e) {
-            System.out.println(e);
-            return null;
-        }
-    }
-
-    public static List<Discount> findAllActiveDiscounts(EntityManager em) {
-
-        try {
-
-            List<Discount> discounts = em.createNamedQuery("findAllActiveDiscounts", Discount.class).getResultList();
-
-            return discounts;
-
-        } catch (Exception e) {
-            System.out.println(e);
-            return null;
-        }
-    }
-
-    public static List<Discount> findDiscountsByNameAndDescription(EntityManager em, String value) {
-
-        try {
-
-            value = value.replaceAll("'", "`");
-
-            List<Discount> discounts
-                    = em.createQuery("SELECT d FROM Discount d WHERE UPPER(d.name) LIKE '%"
-                            + value.toUpperCase().trim() + "%' OR UPPER(d.description) LIKE '%"
-                            + value.toUpperCase().trim() + "%' ORDER BY d.name",
-                            Discount.class).getResultList();
-            return discounts;
-        } catch (Exception e) {
-            System.out.println(e);
-            return new ArrayList<>();
-        }
-    }
-
-    public static List<Discount> findActiveDiscountsByNameAndDescription(EntityManager em, String value) {
-
-        try {
-
-            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
-
-            List<Discount> discounts
-                    = em.createQuery("SELECT d FROM Discount d WHERE (UPPER(d.name) LIKE '%"
-                            + value.toUpperCase().trim() + "%' OR UPPER(d.description) LIKE '%"
-                            + value.toUpperCase().trim() + "%') AND d.active = 1 ORDER BY d.name",
-                            Discount.class).getResultList();
-            return discounts;
-        } catch (Exception e) {
-            System.out.println(e);
-            return new ArrayList<>();
-        }
-    }
 
     @Override
     public Long getId() {
@@ -353,79 +404,24 @@ public class Discount implements Serializable, BusinessEntity {
         this.isDirty = isDirty;
     }
 
-    public static Discount findByName(EntityManager em, String value) {
-
-        try {
-
-            value = value.replaceAll("&amp;", "&").replaceAll("'", "`");
-
-            List<Discount> discounts = em.createQuery("SELECT d FROM Discount d "
-                    + "WHERE UPPER(d.name) "
-                    + "= '" + value.toUpperCase() + "'", Discount.class).getResultList();
-            if (!discounts.isEmpty()) {
-                return discounts.get(0);
-            }
-            return null;
-        } catch (Exception e) {
-            System.out.println(e);
-            return null;
-        }
-    }
-
-    public static Discount findByValue(EntityManager em, Double value) {
-
-        try {
-
-            List<Discount> discounts = em.createQuery("SELECT d FROM Discount d"
-                    + " WHERE d.discountValue = " + value, Discount.class).getResultList();
-            if (!discounts.isEmpty()) {
-                return discounts.get(0);
-            }
-            return null;
-        } catch (Exception e) {
-            System.out.println(e);
-            return null;
-        }
-    }
-
-    public static Discount findByValueAndType(EntityManager em,
-            Double value,
-            String valueType) {
-
-        try {
-
-            valueType = valueType.replaceAll("&amp;", "&").replaceAll("'", "`");
-
-            List<Discount> discounts = em.createQuery("SELECT d FROM Discount d"
-                    + " WHERE d.discountValue = " + value
-                    + " AND d.discountValueType LIKE '" + valueType + "'", Discount.class).getResultList();
-            if (!discounts.isEmpty()) {
-                return discounts.get(0);
-            }
-            return null;
-        } catch (Exception e) {
-            System.out.println(e);
-            return null;
-        }
-    }
 
     @Override
-    public Date getDateEntered() {
+    public LocalDateTime getDateEntered() {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public void setDateEntered(Date dateEntered) {
+    public void setDateEntered(LocalDateTime dateEntered) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public Date getDateEdited() {
+    public LocalDateTime getDateEdited() {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 
     @Override
-    public void setDateEdited(Date dateEdited) {
+    public void setDateEdited(LocalDateTime dateEdited) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
 

--- a/src/main/java/jm/com/dpbennett/business/entity/rm/DatePeriod.java
+++ b/src/main/java/jm/com/dpbennett/business/entity/rm/DatePeriod.java
@@ -19,21 +19,20 @@ Email: info@dpbennett.com.jm
  */
 package jm.com.dpbennett.business.entity.rm;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import java.text.Collator;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
-import javax.persistence.Entity;
-import javax.persistence.EntityManager;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Table;
-import javax.persistence.Temporal;
-import javax.persistence.Transient;
 import jm.com.dpbennett.business.entity.BusinessEntity;
 import jm.com.dpbennett.business.entity.Person;
 import jm.com.dpbennett.business.entity.sm.SystemOption;
@@ -46,9 +45,81 @@ import jm.com.dpbennett.business.entity.util.ReturnMessage;
  */
 @Entity
 @Table(name = "dateperiod")
-public class DatePeriod implements BusinessEntity, Comparable {
+public class DatePeriod implements BusinessEntity, Comparable<DatePeriod> {
 
     private static final long serialVersionUID = 1L;
+    private static final DateTimeFormatter MEDIUM_DATE_FORMATTER = DateTimeFormatter.ofPattern("MMM dd, yyyy");
+    private static final System.Logger LOG = System.getLogger(DatePeriod.class.getName());
+    private static LocalDateTime toLocalDateTime(Date date) {
+        if (date == null) {
+            return null;
+        }
+        
+        return LocalDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault());
+    }
+    private static Date toDate(LocalDateTime localDateTime) {
+        if (localDateTime == null) {
+            return null;
+        }
+        
+        return Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
+    }
+    private static LocalDateTime startOfDay(LocalDateTime dateTime) {
+        if (dateTime == null) {
+            return null;
+        }
+        
+        return dateTime.toLocalDate().atStartOfDay();
+    }
+    private static LocalDateTime createDate(int year, int month, int day) {
+        return LocalDateTime.of(year, month, day, 0, 0, 0, 0);
+    }
+    private static LocalDateTime getStartOfCurrentMonth(LocalDateTime referenceDate) {
+        return referenceDate.withDayOfMonth(1).toLocalDate().atStartOfDay();
+    }
+    private static LocalDateTime getEndOfCurrentMonth(LocalDateTime referenceDate) {
+        return referenceDate.withDayOfMonth(referenceDate.toLocalDate().lengthOfMonth()).toLocalDate().atStartOfDay();
+    }
+    private static LocalDateTime getStartOfCurrentYear(LocalDateTime referenceDate) {
+        return createDate(referenceDate.getYear(), 1, 1);
+    }
+    private static LocalDateTime getEndOfCurrentYear(LocalDateTime referenceDate) {
+        return createDate(referenceDate.getYear(), 12, 31);
+    }
+    private static LocalDateTime getStartOfPreviousYear(LocalDateTime referenceDate) {
+        return createDate(referenceDate.getYear() - 1, 1, 1);
+    }
+    private static LocalDateTime getEndOfPreviousYear(LocalDateTime referenceDate) {
+        return createDate(referenceDate.getYear() - 1, 12, 31);
+    }
+    private static String formatMediumDate(LocalDateTime dateTime) {
+        if (dateTime == null) {
+            return "";
+        }
+        
+        return MEDIUM_DATE_FORMATTER.format(dateTime);
+    }
+    public static DatePeriod findById(EntityManager em, Long id) {
+        return em.find(DatePeriod.class, id);
+    }
+    public static List<String> getDatePeriodNames() {
+        ArrayList<String> names = new ArrayList<>();
+        
+        names.add("This month");
+        names.add("This month last year");
+        names.add("This financial month");
+        names.add("This financial year");
+        names.add("This year to date");
+        names.add("This year");
+        names.add("Last month");
+        names.add("Last financial month");
+        names.add("Last financial year");
+        names.add("Last year");
+        names.add("Custom");
+        
+        return names;
+    }
+
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
@@ -56,10 +127,8 @@ public class DatePeriod implements BusinessEntity, Comparable {
     private String type;
     private String dateField;
     private String label;
-    @Temporal(javax.persistence.TemporalType.DATE)
-    private Date startDate;
-    @Temporal(javax.persistence.TemporalType.DATE)
-    private Date endDate;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
     private Boolean startDateDisabled;
     private Boolean endDateDisabled;
     @Transient
@@ -77,8 +146,8 @@ public class DatePeriod implements BusinessEntity, Comparable {
             String type,
             String dateField,
             String label,
-            Date startDate,
-            Date endDate,
+            LocalDateTime startDate,
+            LocalDateTime endDate,
             Boolean startDateDisabled,
             Boolean endDateDisabled,
             Boolean init) {
@@ -93,10 +162,38 @@ public class DatePeriod implements BusinessEntity, Comparable {
         this.endDateDisabled = endDateDisabled;
         this.init = init;
 
-        if (init) {
+        if (Boolean.TRUE.equals(init)) {
             init();
         }
     }
+
+    /**
+     * Compatibility constructor for older callers that still pass java.util.Date.
+     * Prefer the LocalDateTime constructor in new code.
+     */
+    public DatePeriod(
+            String name,
+            String type,
+            String dateField,
+            String label,
+            Date startDate,
+            Date endDate,
+            Boolean startDateDisabled,
+            Boolean endDateDisabled,
+            Boolean init) {
+
+        this(
+                name,
+                type,
+                dateField,
+                label,
+                toLocalDateTime(startDate),
+                toLocalDateTime(endDate),
+                startDateDisabled,
+                endDateDisabled,
+                init);
+    }
+
 
     public Boolean getShow() {
         if (show == null) {
@@ -109,11 +206,6 @@ public class DatePeriod implements BusinessEntity, Comparable {
         this.show = show;
     }
 
-    public static DatePeriod findById(EntityManager em, Long id) {
-
-        return em.find(DatePeriod.class, id);
-
-    }
 
     public String getLabel() {
         if (label == null) {
@@ -180,23 +272,6 @@ public class DatePeriod implements BusinessEntity, Comparable {
         this.type = type;
     }
 
-    public static List<String> getDatePeriodNames() {
-        ArrayList<String> names = new ArrayList<>();
-
-        names.add("This month");
-        names.add("This month last year");
-        names.add("This financial month");
-        names.add("This financial year");
-        names.add("This year to date");
-        names.add("This year");
-        names.add("Last month");
-        names.add("Last financial month");
-        names.add("Last financial year");
-        names.add("Last year");
-        names.add("Custom");
-
-        return names;
-    }
 
     public Boolean getEndDateDisabled() {
         return endDateDisabled;
@@ -214,90 +289,104 @@ public class DatePeriod implements BusinessEntity, Comparable {
         this.startDateDisabled = startDateDisabled;
     }
 
-    public Date getEndDate() {
+    public LocalDateTime getEndDate() {
         if (endDate == null) {
             initDatePeriod();
         }
+
         return endDate;
     }
 
-    public void setEndDate(Date endDate) {
+    public void setEndDate(LocalDateTime endDate) {
         this.endDate = endDate;
     }
 
-    public Date getStartDate() {
+    /**
+     * Compatibility setter for older JSF/utility code that still passes java.util.Date.
+     */
+    public void setEndDate(Date endDate) {
+        this.endDate = toLocalDateTime(endDate);
+    }
+
+    public LocalDateTime getStartDate() {
         if (startDate == null) {
             initDatePeriod();
         }
         return startDate;
     }
 
-    public void setStartDate(Date startDate) {
+    public void setStartDate(LocalDateTime startDate) {
         this.startDate = startDate;
     }
 
+    /**
+     * Compatibility setter for older JSF/utility code that still passes java.util.Date.
+     */
+    public void setStartDate(Date startDate) {
+        this.startDate = toLocalDateTime(startDate);
+    }
+
+    public Date getStartDateAsDate() {
+        return toDate(getStartDate());
+    }
+
+    public Date getEndDateAsDate() {
+        return toDate(getEndDate());
+    }
+
     public String getFormattedStartDate() {
-        return BusinessEntityUtils.getDateInMediumDateFormat(getStartDate());
+        return formatMediumDate(getStartDate());
     }
 
     public String getFormattedEndDate() {
-        return BusinessEntityUtils.getDateInMediumDateFormat(getEndDate());
+        return formatMediumDate(getEndDate());
     }
 
-    public void initFinancialMonthPeriod(Date baseDate) {
-        Calendar c = Calendar.getInstance();
-
-        c.setTime(baseDate);
-        Date edate = BusinessEntityUtils.createDate(
-                c.get(Calendar.YEAR),
-                c.get(Calendar.MONTH),
-                25);
-
-        Calendar edateCal = Calendar.getInstance();
-        edateCal.setTime(edate);
-        edateCal.add(Calendar.MONTH, -1);
-        edateCal.add(Calendar.DAY_OF_MONTH, 1);
-        Date sdate = edateCal.getTime();
+    public void initFinancialMonthPeriod(LocalDateTime baseDate) {
+        LocalDateTime referenceDate = startOfDay(baseDate != null ? baseDate : LocalDateTime.now());
+        LocalDateTime edate = createDate(referenceDate.getYear(), referenceDate.getMonthValue(), 25);
+        LocalDateTime sdate = edate.minusMonths(1).plusDays(1);
 
         setStartDate(sdate);
         setEndDate(edate);
     }
 
-    public void initFinancialYearPeriod(Date refDate) {
-        Calendar referenceCalendar = Calendar.getInstance();
+    /**
+     * Compatibility overload for older callers that still pass java.util.Date.
+     */
+    public void initFinancialMonthPeriod(Date baseDate) {
+        initFinancialMonthPeriod(toLocalDateTime(baseDate));
+    }
 
-        referenceCalendar.setTime(refDate);
+    public void initFinancialYearPeriod(LocalDateTime refDate) {
+        LocalDateTime referenceDate = startOfDay(refDate != null ? refDate : LocalDateTime.now());
+        int referenceYear = referenceDate.getYear();
 
-        Date referenceDate = BusinessEntityUtils.createDate(
-                referenceCalendar.get(Calendar.YEAR),
-                referenceCalendar.get(Calendar.MONTH),
-                referenceCalendar.get(Calendar.DAY_OF_MONTH));
+        LocalDateTime referenceStartOfFinancialYear = createDate(referenceYear, 4, 1);
+        LocalDateTime referenceEndOfFinancialYear = createDate(referenceYear, 3, 31);
+        LocalDateTime referenceStartOfYear = createDate(referenceYear, 1, 1);
+        LocalDateTime referenceEndOfYear = createDate(referenceYear, 12, 31);
 
-        int referenceYear = referenceCalendar.get(Calendar.YEAR);
-        Date referenceStartOfFinancialYear = BusinessEntityUtils.createDate(referenceYear, 3, 1);
-        Date referenceEndOfFinancialYear = BusinessEntityUtils.createDate(referenceYear, 2, 31);
-        Date referenceStartOfYear = BusinessEntityUtils.createDate(referenceYear, 0, 1);
-        Date referenceEndOfYear = BusinessEntityUtils.createDate(referenceYear, 11, 31);
-
-        if (referenceDate.equals(referenceStartOfYear)) {
-            setStartDate(BusinessEntityUtils.createDate(referenceYear - 1, 3, 1));
+        if (referenceDate.equals(referenceStartOfYear)
+                || (referenceDate.isAfter(referenceStartOfYear) && referenceDate.isBefore(referenceEndOfFinancialYear))
+                || referenceDate.equals(referenceEndOfFinancialYear)) {
+            setStartDate(createDate(referenceYear - 1, 4, 1));
             setEndDate(referenceEndOfFinancialYear);
-        } else if (referenceDate.after(referenceStartOfYear)
-                && referenceDate.before(referenceEndOfFinancialYear)) {
-            setStartDate(BusinessEntityUtils.createDate(referenceYear - 1, 3, 1));
-            setEndDate(referenceEndOfFinancialYear);
-        } else if (referenceDate.equals(referenceEndOfFinancialYear)) {
-            setStartDate(BusinessEntityUtils.createDate(referenceYear - 1, 3, 1));
-            setEndDate(referenceEndOfFinancialYear);
-        } else if (referenceDate.after(referenceEndOfFinancialYear)
-                && referenceDate.before(referenceEndOfYear)) {
+        } else if (referenceDate.isAfter(referenceEndOfFinancialYear)
+                && referenceDate.isBefore(referenceEndOfYear)) {
             setStartDate(referenceStartOfFinancialYear);
-            setEndDate(BusinessEntityUtils.createDate(referenceYear + 1, 2, 31));
+            setEndDate(createDate(referenceYear + 1, 3, 31));
         } else {
             setStartDate(referenceStartOfFinancialYear);
-            setEndDate(BusinessEntityUtils.createDate(referenceYear + 1, 2, 31));
+            setEndDate(createDate(referenceYear + 1, 3, 31));
         }
+    }
 
+    /**
+     * Compatibility overload for older callers that still pass java.util.Date.
+     */
+    public void initFinancialYearPeriod(Date refDate) {
+        initFinancialYearPeriod(toLocalDateTime(refDate));
     }
 
     public DatePeriod getInitDatePeriod() {
@@ -305,67 +394,75 @@ public class DatePeriod implements BusinessEntity, Comparable {
     }
 
     public DatePeriod initDatePeriod() {
-        return initDatePeriod(new Date());
+        return initDatePeriod(LocalDateTime.now());
     }
 
-    public DatePeriod initDatePeriod(Date referencDate) {
+    /**
+     * Compatibility overload for older callers that still pass java.util.Date.
+     */
+    public DatePeriod initDatePeriod(Date referenceDate) {
+        return initDatePeriod(toLocalDateTime(referenceDate));
+    }
+
+    public DatePeriod initDatePeriod(LocalDateTime referenceDate) {
+        LocalDateTime refDate = startOfDay(referenceDate != null ? referenceDate : LocalDateTime.now());
 
         switch (getName()) {
             case "This month":
-                setStartDate(BusinessEntityUtils.getStartOfCurrentMonth());
-                setEndDate(BusinessEntityUtils.getEndOfCurrentMonth());
+                setStartDate(getStartOfCurrentMonth(refDate));
+                setEndDate(getEndOfCurrentMonth(refDate));
                 setStartDateDisabled(true);
                 setEndDateDisabled(true);
                 break;
             case "This month last year":
-                setStartDate(BusinessEntityUtils.getStartOfCurrentMonthPreviousYear());
-                setEndDate(BusinessEntityUtils.getEndOfCurrentMonthPreviousYear());
+                setStartDate(getStartOfCurrentMonth(refDate).minusYears(1));
+                setEndDate(getEndOfCurrentMonth(refDate).minusYears(1));
                 setStartDateDisabled(true);
                 setEndDateDisabled(true);
                 break;
             case "This financial month":
-                initFinancialMonthPeriod(BusinessEntityUtils.createDate(referencDate));
+                initFinancialMonthPeriod(refDate);
                 setStartDateDisabled(true);
                 setEndDateDisabled(true);
                 break;
             case "This financial year":
-                initFinancialYearPeriod(referencDate);
+                initFinancialYearPeriod(refDate);
                 setStartDateDisabled(true);
                 setEndDateDisabled(true);
                 break;
             case "This year to date":
-                setStartDate(BusinessEntityUtils.getStartOfCurrentYear());
-                setEndDate(BusinessEntityUtils.createDate(referencDate));
+                setStartDate(getStartOfCurrentYear(refDate));
+                setEndDate(refDate);
                 setStartDateDisabled(true);
                 setEndDateDisabled(true);
                 break;
             case "This year":
-                setStartDate(BusinessEntityUtils.getStartOfCurrentYear());
-                setEndDate(BusinessEntityUtils.getEndOfCurrentYear());
+                setStartDate(getStartOfCurrentYear(refDate));
+                setEndDate(getEndOfCurrentYear(refDate));
                 setStartDateDisabled(true);
                 setEndDateDisabled(true);
                 break;
             case "Last month":
-                setStartDate(BusinessEntityUtils.getStartOfLastMonth());
-                setEndDate(BusinessEntityUtils.getEndOfLastMonth());
+                setStartDate(getStartOfCurrentMonth(refDate).minusMonths(1));
+                setEndDate(getStartOfCurrentMonth(refDate).minusDays(1));
                 setStartDateDisabled(true);
                 setEndDateDisabled(true);
                 break;
             case "Last financial month":
-                initFinancialMonthPeriod(BusinessEntityUtils.getEndOfLastMonth());
+                initFinancialMonthPeriod(getStartOfCurrentMonth(refDate).minusDays(1));
                 setStartDateDisabled(true);
                 setEndDateDisabled(true);
                 break;
             case "Last financial year":
-                initFinancialYearPeriod(BusinessEntityUtils.createDate(referencDate));
-                startDate = BusinessEntityUtils.adjustDate(startDate, Calendar.YEAR, -1);
-                endDate = BusinessEntityUtils.adjustDate(endDate, Calendar.YEAR, -1);
+                initFinancialYearPeriod(refDate);
+                setStartDate(startDate.minusYears(1));
+                setEndDate(endDate.minusYears(1));
                 setStartDateDisabled(true);
                 setEndDateDisabled(true);
                 break;
             case "Last year":
-                setStartDate(BusinessEntityUtils.getStartOfPreviousYear());
-                setEndDate(BusinessEntityUtils.getEndOfPreviousYear());
+                setStartDate(getStartOfPreviousYear(refDate));
+                setEndDate(getEndOfPreviousYear(refDate));
                 setStartDateDisabled(true);
                 setEndDateDisabled(true);
                 break;
@@ -380,7 +477,6 @@ public class DatePeriod implements BusinessEntity, Comparable {
         }
 
         return this;
-
     }
 
     @Override
@@ -402,9 +498,7 @@ public class DatePeriod implements BusinessEntity, Comparable {
 
     @Override
     public String toString() {
-        DateFormat formatter = new SimpleDateFormat("MMM dd, yyyy");
-
-        return getName() + " (" + formatter.format(startDate) + " to " + formatter.format(endDate) + ")";
+        return getName() + " (" + getPeriodString() + ")";
     }
 
     @Override
@@ -416,9 +510,7 @@ public class DatePeriod implements BusinessEntity, Comparable {
     }
 
     public String getPeriodString() {
-        DateFormat formatter = new SimpleDateFormat("MMM dd, yyyy");
-
-        return formatter.format(startDate) + " to " + formatter.format(endDate);
+        return formatMediumDate(getStartDate()) + " to " + formatMediumDate(getEndDate());
     }
 
     @Override
@@ -429,7 +521,6 @@ public class DatePeriod implements BusinessEntity, Comparable {
     @Override
     public ReturnMessage save(EntityManager em) {
         try {
-
             em.getTransaction().begin();
             BusinessEntityUtils.saveBusinessEntity(em, this);
             em.getTransaction().commit();
@@ -448,9 +539,9 @@ public class DatePeriod implements BusinessEntity, Comparable {
     }
 
     @Override
-    public int compareTo(Object o) {
-        if (((DatePeriod) o).getId() != null && this.getId() != null) {
-            return Collator.getInstance().compare(this.getId().toString(), ((DatePeriod) o).getId().toString());
+    public int compareTo(DatePeriod o) {
+        if (o != null && o.getId() != null && this.getId() != null) {
+            return Collator.getInstance().compare(this.getId().toString(), o.getId().toString());
         } else {
             return 1;
         }
@@ -458,121 +549,121 @@ public class DatePeriod implements BusinessEntity, Comparable {
 
     @Override
     public Boolean getActive() {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @Override
     public void setActive(Boolean active) {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @Override
     public String getCategory() {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @Override
     public void setCategory(String category) {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @Override
-    public Date getDateEntered() {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    public LocalDateTime getDateEntered() {
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @Override
-    public void setDateEntered(Date dateEntered) {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    public void setDateEntered(LocalDateTime dateEntered) {
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @Override
-    public Date getDateEdited() {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    public LocalDateTime getDateEdited() {
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @Override
-    public void setDateEdited(Date dateEdited) {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    public void setDateEdited(LocalDateTime dateEdited) {
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @Override
     public ReturnMessage delete(EntityManager em) {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @Override
     public String getDescription() {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @Override
     public void setDescription(String description) {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @Override
     public String getNotes() {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @Override
     public void setNotes(String notes) {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @Override
     public String getComments() {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @Override
     public void setComments(String comments) {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @Override
     public Person getEditedBy() {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @Override
     public void setEditedBy(Person person) {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @Override
     public Person getEnteredBy() {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @Override
     public void setEnteredBy(Person person) {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @Override
     public ReturnMessage saveUnique(EntityManager em) {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @Override
     public List<SystemOption> getSettings() {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @Override
     public void setSettings(List<SystemOption> settings) {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @Override
     public SystemOption getSetting(String setting, String settingValue, String type, String category) {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @Override
     public void setSetting(String setting, String settingValue, String type, String category) {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 }

--- a/src/main/java/jm/com/dpbennett/business/entity/sm/User.java
+++ b/src/main/java/jm/com/dpbennett/business/entity/sm/User.java
@@ -64,6 +64,7 @@ public class User extends DefaultEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
+    private Long ownerId;
     private Boolean active;
     private String username;
     private String PFThemeName;
@@ -102,6 +103,14 @@ public class User extends DefaultEntity {
     public User() {
         employee = new Employee();
         username = "";
+    }
+
+    public Long getOwnerId() {
+        return ownerId;
+    }
+
+    public void setOwnerId(Long ownerId) {
+        this.ownerId = ownerId;
     }
 
     @Override

--- a/src/main/java/jm/com/dpbennett/business/entity/sm/User.java
+++ b/src/main/java/jm/com/dpbennett/business/entity/sm/User.java
@@ -817,10 +817,6 @@ public class User extends DefaultEntity {
             if (employee != null) {
                 employee.save(em);
             }
-//
-//            if (privilege != null) {
-//                privilege.save(em);
-//            }
 
             for (Privilege priv : getPrivileges()) {
                 priv.save(em);

--- a/src/main/java/jm/com/dpbennett/business/entity/util/BusinessEntityUtils.java
+++ b/src/main/java/jm/com/dpbennett/business/entity/util/BusinessEntityUtils.java
@@ -19,29 +19,35 @@ Email: info@dpbennett.com.jm
  */
 package jm.com.dpbennett.business.entity.util;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.Persistence;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import java.text.DateFormat;
 import java.text.DecimalFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.Persistence;
+import jm.com.dpbennett.business.entity.BusinessEntity;
+import jm.com.dpbennett.business.entity.Person;
+import jm.com.dpbennett.business.entity.cm.Client;
 import jm.com.dpbennett.business.entity.fm.AccPacCustomer;
 import jm.com.dpbennett.business.entity.hrm.Address;
-import jm.com.dpbennett.business.entity.BusinessEntity;
-import jm.com.dpbennett.business.entity.cm.Client;
 import jm.com.dpbennett.business.entity.hrm.Contact;
 import jm.com.dpbennett.business.entity.rm.DatePeriod;
-import jm.com.dpbennett.business.entity.Person;
 
 /**
  *
@@ -51,15 +57,19 @@ public class BusinessEntityUtils {
 
     private static EntityManagerFactory EMF;
 
-    public static String MONTH_NAMES[] = {
+    public static final String[] MONTH_NAMES = {
         "January", "February", "March", "April", "May", "June",
         "July", "August", "September", "October", "November", "December"
     };
 
-    public static String ALPHABET[] = {
+    public static final String[] ALPHABET = {
         "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M",
         "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"
     };
+
+    private static final ZoneId DEFAULT_ZONE_ID = ZoneId.systemDefault();
+    private static final DateTimeFormatter MEDIUM_DATE_FORMATTER = DateTimeFormatter.ofPattern("MMM dd, yyyy");
+    private static final DateTimeFormatter MEDIUM_DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("MMM dd, yyyy, h:mm a");
 
     public static String sanitize(String value) {
 
@@ -72,8 +82,8 @@ public class BusinessEntityUtils {
 
     }
 
-    public static Date getNow() {
-        return new Date();
+    public static LocalDateTime getNow() {
+        return LocalDateTime.now();
     }
 
     public static int getLetterIndex(String letter) {
@@ -96,19 +106,20 @@ public class BusinessEntityUtils {
         return false;
     }
 
-    public static Boolean isDateWithinPeriod(Date dateToCheck, Date startDate, Date endDate) {
-        return (dateToCheck.compareTo(startDate) >= 0) && (dateToCheck.compareTo(endDate) <= 0);
+    public static Boolean isDateWithinPeriod(LocalDateTime dateToCheck, LocalDateTime startDate, LocalDateTime endDate) {
+        return dateToCheck != null
+                && startDate != null
+                && endDate != null
+                && !dateToCheck.isBefore(startDate)
+                && !dateToCheck.isAfter(endDate);
     }
 
-    public static String getMonthAndYearString(Date date) {
-        String dateMonthAndYearString;
-        Calendar c = Calendar.getInstance();
+    public static String getMonthAndYearString(LocalDateTime date) {
+        if (date == null) {
+            return "";
+        }
 
-        c.setTime(date);
-        dateMonthAndYearString = MONTH_NAMES[c.get(Calendar.MONTH)];
-        dateMonthAndYearString = dateMonthAndYearString + " " + getYearFromDate(date);
-
-        return dateMonthAndYearString;
+        return MONTH_NAMES[date.getMonthValue() - 1] + " " + date.getYear();
     }
 
     public static String getBasicAddress(Address address) {
@@ -264,15 +275,12 @@ public class BusinessEntityUtils {
 
         switch (type) {
             case "java.lang.Long":
-                return Boolean.TRUE;
             case "java.lang.Integer":
-                return Boolean.TRUE;
             case "java.lang.Double":
-                return Boolean.TRUE;
             case "java.lang.Boolean":
-                return Boolean.TRUE;
             case "java.lang.String":
-                return Boolean.TRUE;
+            case "java.time.LocalDate":
+            case "java.time.LocalDateTime":
             case "java.util.Date":
                 return Boolean.TRUE;
             default:
@@ -289,7 +297,7 @@ public class BusinessEntityUtils {
         try {
 
             String[] methodNames = methodPath.split("/");
-            Class c = Class.forName(methodNames[0]);
+            Class<?> c = Class.forName(methodNames[0]);
             String[] methodName = methodNames[1].split("\\.");
 
             do {
@@ -311,10 +319,10 @@ public class BusinessEntityUtils {
         }
     }
 
-    public static Class getClass(String methodPath) {
+    public static Class<?> getClass(String methodPath) {
         int i = 0;
         Method method;
-        Class c;
+        Class<?> c;
 
         try {
 
@@ -344,7 +352,7 @@ public class BusinessEntityUtils {
     public static Object getBusinessEntityValue(Object entity, String methodPath) {
 
         Object value = null;
-        Class c;
+        Class<?> c;
         Method m;
 
         String[] path = methodPath.split("/");
@@ -382,6 +390,7 @@ public class BusinessEntityUtils {
                 em.merge(businessEntity);
             } else {
                 em.persist(businessEntity);
+                em.flush();
             }
 
             return businessEntity.getId();
@@ -404,176 +413,101 @@ public class BusinessEntityUtils {
             em.getTransaction().commit();
 
         } catch (Exception e) {
+            if (em != null && em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
             System.out.println(e);
         }
     }
 
-    public static Date createDate(int year, int monthIndex, int day) {
-        Calendar c;
-
-        c = Calendar.getInstance();
-        c.clear();
-        c.set(year, monthIndex, day, 0, 0, 0);
-
-        return c.getTime();
+    public static LocalDateTime createDate(int year, int monthIndex, int day) {
+        return LocalDateTime.of(year, monthIndex + 1, day, 0, 0, 0, 0);
     }
 
-    public static Date createDate(Date date) {
-        Calendar c;
-
-        c = Calendar.getInstance();
-        c.clear();
-        c.setTime(date);
-        c.set(c.get(Calendar.YEAR), c.get(Calendar.MONTH), c.get(Calendar.DAY_OF_MONTH), 0, 0, 0);
-        c.set(Calendar.MILLISECOND, 0);
-
-        return c.getTime();
-    }
-
-    public static int getYearFromDate(Date date) {
-        Calendar c;
-
-        c = Calendar.getInstance();
-        c.setTime(date);
-
-        return c.get(Calendar.YEAR);
-    }
-
-    public static Date getStartOfCurrentYear() {
-        Calendar c, current;
-
-        current = Calendar.getInstance();
-        c = Calendar.getInstance();
-        c.set(current.get(Calendar.YEAR), Calendar.JANUARY, 1, 0, 0, 0);
-        c.set(Calendar.MILLISECOND, 0);
-
-        return c.getTime();
-    }
-
-    public static Date getEndOfCurrentYear() {
-        Calendar c, current;
-
-        current = Calendar.getInstance();
-        c = Calendar.getInstance();
-        c.set(current.get(Calendar.YEAR), Calendar.DECEMBER, 31, 0, 0, 0);
-        c.set(Calendar.MILLISECOND, 0);
-
-        return c.getTime();
-    }
-
-    public static Date getStartOfCurrentMonth() {
-        Calendar c, current;
-
-        current = Calendar.getInstance();
-        c = Calendar.getInstance();
-        c.set(current.get(Calendar.YEAR), current.get(Calendar.MONTH), 1, 0, 0, 0);
-        c.set(Calendar.MILLISECOND, 0);
-
-        return c.getTime();
-    }
-
-    public static Date getStartOfCurrentMonthPreviousYear() {
-        Calendar c, current;
-
-        current = Calendar.getInstance();
-        c = Calendar.getInstance();
-        c.set(current.get(Calendar.YEAR) - 1, current.get(Calendar.MONTH), 1, 0, 0, 0);
-        c.set(Calendar.MILLISECOND, 0);
-
-        return c.getTime();
-    }
-
-    public static Date getStartOfMonthInCurrentYear(int monthIndex) {
-        Calendar c, current;
-
-        current = Calendar.getInstance();
-        c = Calendar.getInstance();
-        c.set(current.get(Calendar.YEAR), monthIndex, 1, 0, 0, 0);
-        c.set(Calendar.MILLISECOND, 0);
-
-        return c.getTime();
-    }
-
-    public static Date getEndOfCurrentMonth() {
-        Calendar c, current;
-
-        current = Calendar.getInstance();
-        c = Calendar.getInstance();
-        c.set(current.get(Calendar.YEAR), current.get(Calendar.MONTH), getDaysInMonth(current.get(Calendar.MONTH)), 0, 0, 0);
-        c.set(Calendar.MILLISECOND, 0);
-
-        return c.getTime();
-    }
-
-    public static Date getEndOfCurrentMonthPreviousYear() {
-        Calendar c, current;
-
-        current = Calendar.getInstance();
-        c = Calendar.getInstance();
-        c.set(current.get(Calendar.YEAR) - 1, current.get(Calendar.MONTH), getDaysInMonth(current.get(Calendar.MONTH)), 0, 0, 0);
-        c.set(Calendar.MILLISECOND, 0);
-
-        return c.getTime();
-    }
-
-    public static Date getThisDatePreviousYear() {
-        Calendar c, current;
-
-        current = Calendar.getInstance();
-        c = Calendar.getInstance();
-        c.set(current.get(Calendar.YEAR) - 1, current.get(Calendar.MONTH), getDaysInMonth(current.get(Calendar.MONTH)), 0, 0, 0);
-        c.set(Calendar.MILLISECOND, 0);
-
-        return c.getTime();
-    }
-
-    public static Date getEndOfMonthInCurrentYear(int monthIndex) {
-        Calendar c, current;
-
-        current = Calendar.getInstance();
-        c = Calendar.getInstance();
-        c.set(current.get(Calendar.YEAR), monthIndex, getDaysInMonth(monthIndex), 0, 0, 0);
-        c.set(Calendar.MILLISECOND, 0);
-
-        return c.getTime();
-    }
-
-    public static int getDaysInMonth(int month) {
-        Calendar current = Calendar.getInstance();
-
-        switch (month) {
-            case Calendar.JANUARY:
-                return 31;
-            case Calendar.FEBRUARY:
-                int currentYear = current.get(Calendar.YEAR);
-                if ((currentYear % 4) == 0) { // leap year?
-                    return 29;
-                } else {
-                    return 28;
-                }
-            case Calendar.MARCH:
-                return 31;
-            case Calendar.APRIL:
-                return 30;
-            case Calendar.MAY:
-                return 31;
-            case Calendar.JUNE:
-                return 30;
-            case Calendar.JULY:
-                return 31;
-            case Calendar.AUGUST:
-                return 31;
-            case Calendar.SEPTEMBER:
-                return 30;
-            case Calendar.OCTOBER:
-                return 31;
-            case Calendar.NOVEMBER:
-                return 30;
-            case Calendar.DECEMBER:
-                return 31;
-            default:
-                return -1;
+    public static LocalDateTime createDate(LocalDateTime date) {
+        if (date == null) {
+            return null;
         }
+
+        return date.toLocalDate().atStartOfDay();
+    }
+
+    public static LocalDateTime createDate(LocalDate date) {
+        if (date == null) {
+            return null;
+        }
+
+        return date.atStartOfDay();
+    }
+
+    public static LocalDateTime toLocalDateTime(Date date) {
+        if (date == null) {
+            return null;
+        }
+
+        return LocalDateTime.ofInstant(date.toInstant(), DEFAULT_ZONE_ID);
+    }
+
+    public static Date toDate(LocalDateTime dateTime) {
+        if (dateTime == null) {
+            return null;
+        }
+
+        return Date.from(dateTime.atZone(DEFAULT_ZONE_ID).toInstant());
+    }
+
+    /**
+     * Compatibility helper for legacy callers. Prefer createDate(LocalDateTime).
+     */
+    public static LocalDateTime createDate(Date date) {
+        return createDate(toLocalDateTime(date));
+    }
+
+    public static int getYearFromDate(LocalDateTime date) {
+        return date != null ? date.getYear() : 0;
+    }
+
+    public static LocalDateTime getStartOfCurrentYear() {
+        return LocalDate.now().withDayOfYear(1).atStartOfDay();
+    }
+
+    public static LocalDateTime getEndOfCurrentYear() {
+        LocalDate today = LocalDate.now();
+        return LocalDate.of(today.getYear(), 12, 31).atStartOfDay();
+    }
+
+    public static LocalDateTime getStartOfCurrentMonth() {
+        return YearMonth.now().atDay(1).atStartOfDay();
+    }
+
+    public static LocalDateTime getStartOfCurrentMonthPreviousYear() {
+        LocalDate today = LocalDate.now();
+        return LocalDate.of(today.getYear() - 1, today.getMonth(), 1).atStartOfDay();
+    }
+
+    public static LocalDateTime getStartOfMonthInCurrentYear(int monthIndex) {
+        return LocalDate.of(LocalDate.now().getYear(), monthIndex + 1, 1).atStartOfDay();
+    }
+
+    public static LocalDateTime getEndOfCurrentMonth() {
+        return YearMonth.now().atEndOfMonth().atStartOfDay();
+    }
+
+    public static LocalDateTime getEndOfCurrentMonthPreviousYear() {
+        LocalDate today = LocalDate.now();
+        return YearMonth.of(today.getYear() - 1, today.getMonth()).atEndOfMonth().atStartOfDay();
+    }
+
+    public static LocalDateTime getThisDatePreviousYear() {
+        return LocalDate.now().minusYears(1).atStartOfDay();
+    }
+
+    public static LocalDateTime getEndOfMonthInCurrentYear(int monthIndex) {
+        return YearMonth.of(LocalDate.now().getYear(), monthIndex + 1).atEndOfMonth().atStartOfDay();
+    }
+
+    public static int getDaysInMonth(int monthIndex) {
+        return YearMonth.of(LocalDate.now().getYear(), monthIndex + 1).lengthOfMonth();
     }
 
     public static String getIntegerString(long number, int digits) {
@@ -583,47 +517,39 @@ public class BusinessEntityUtils {
         return string;
     }
 
-    public static String getDateString(Date d, String delim, String format, String sep) {
+    public static String getDateString(LocalDateTime d, String delim, String format, String sep) {
         if (d != null) {
-            Calendar c = Calendar.getInstance();
-            c.setTime(d);
-            return getDateString(c, delim, format, sep);
+            return getDateString(d.toLocalDate(), delim, format, sep);
         } else {
             return "";
         }
     }
 
-    public static String getDateInMediumDateFormat(Date date) {
-        DateFormat formatter = new SimpleDateFormat("MMM dd, yyyy");
-
+    public static String getDateInMediumDateFormat(LocalDateTime date) {
         if (date != null) {
-            return formatter.format(date);
+            return date.format(MEDIUM_DATE_FORMATTER);
         } else {
             return "";
         }
     }
 
-    public static String getUserDefinedDateFormat(Date date, String format) {
-        DateFormat formatter = new SimpleDateFormat(format);
-
+    public static String getUserDefinedDateFormat(LocalDateTime date, String format) {
         if (date != null) {
-            return formatter.format(date);
+            return date.format(DateTimeFormatter.ofPattern(format));
         } else {
             return "";
         }
     }
 
-    public static String getDateInMediumDateAndTimeFormat(Date date) {
-        DateFormat formatter = new SimpleDateFormat("MMM dd, yyyy, h:mm a");
-
+    public static String getDateInMediumDateAndTimeFormat(LocalDateTime date) {
         if (date != null) {
-            return formatter.format(date);
+            return date.format(MEDIUM_DATE_TIME_FORMATTER);
         } else {
             return "";
         }
     }
 
-    public static String getDateString(Calendar c, String delim, String format, String sep) {
+    public static String getDateString(LocalDate date, String delim, String format, String sep) {
         if (delim == null) {
             delim = "'";
         }
@@ -634,11 +560,11 @@ public class BusinessEntityUtils {
             sep = "-";
         }
 
-        if (c != null) {
+        if (date != null) {
             String str;
-            String year = getIntegerString(c.get(Calendar.YEAR), 4);
-            int month = c.get(Calendar.MONTH) + 1;
-            int day = c.get(Calendar.DAY_OF_MONTH);
+            String year = getIntegerString(date.getYear(), 4);
+            int month = date.getMonthValue();
+            int day = date.getDayOfMonth();
             switch (format) {
                 case "YMD":
                     str = delim + year + sep + month + sep + day + delim;
@@ -665,108 +591,57 @@ public class BusinessEntityUtils {
             String format,
             String sep) {
 
-        return getDateString(c, delim, format, sep);
+        return getDateString(toLocalDateTime(c.getTime()), delim, format, sep);
     }
 
     public static String getDateStringFromDate(
-            Date d,
+            LocalDateTime d,
             String delim,
             String format,
             String sep) {
-        if (d != null) {
-            Calendar c = Calendar.getInstance();
-            c.setTime(d);
-            return getDateString(c, delim, format, sep);
-        } else {
-            return "";
-        }
+        return getDateString(d, delim, format, sep);
     }
 
-    public static Date getDateFromInt(int dateInt) {
-        Calendar c = Calendar.getInstance();
+    public static LocalDateTime getDateFromInt(int dateInt) {
         String dateString = "" + dateInt;
 
         int year = Integer.parseInt(dateString.substring(0, 4));
         int month = Integer.parseInt(dateString.substring(4, 6));
         int day = Integer.parseInt(dateString.substring(6, 8));
 
-        c.set(year, month - 1, day);
-        return c.getTime();
+        return LocalDateTime.of(year, month, day, 0, 0);
     }
 
-    public static int getIntFromDate(Date date) {
-        Calendar c = Calendar.getInstance();
-        c.setTime(date);
-
-        String yearStr = String.format("%04d", c.get(Calendar.YEAR));
-        String monthStr = String.format("%02d", c.get(Calendar.MONTH) + 1);
-        String dayStr = String.format("%02d", c.get(Calendar.DAY_OF_MONTH));
-
-        return Integer.parseInt(yearStr + monthStr + dayStr);
+    public static int getIntFromDate(LocalDateTime date) {
+        return Integer.parseInt(date.format(DateTimeFormatter.BASIC_ISO_DATE));
     }
 
     public static int getPreviousYear() {
-        Calendar c;
-
-        c = Calendar.getInstance();
-
-        return c.get(Calendar.YEAR) - 1;
+        return Year.now().getValue() - 1;
     }
 
     public static int getCurrentYear() {
-
-        Calendar c = Calendar.getInstance();
-
-        return c.get(Calendar.YEAR);
+        return Year.now().getValue();
     }
 
     public static int getNextYear() {
-
-        Calendar c = Calendar.getInstance();
-
-        return c.get(Calendar.YEAR) + 1;
+        return Year.now().getValue() + 1;
     }
 
-    public static Date getStartOfPreviousYear() {
-        Calendar c, current;
-
-        current = Calendar.getInstance();
-        c = Calendar.getInstance();
-        c.set(current.get(Calendar.YEAR) - 1, Calendar.JANUARY, 1, 0, 0, 0);
-        c.set(Calendar.MILLISECOND, 0);
-
-        return c.getTime();
+    public static LocalDateTime getStartOfPreviousYear() {
+        return LocalDate.of(LocalDate.now().getYear() - 1, 1, 1).atStartOfDay();
     }
 
-    public static Date getEndOfPreviousYear() {
-        Calendar c, current;
-
-        current = Calendar.getInstance();
-        c = Calendar.getInstance();
-        c.set(current.get(Calendar.YEAR) - 1, Calendar.DECEMBER, 31, 0, 0, 0);
-        c.set(Calendar.MILLISECOND, 0);
-
-        return c.getTime();
+    public static LocalDateTime getEndOfPreviousYear() {
+        return LocalDate.of(LocalDate.now().getYear() - 1, 12, 31).atStartOfDay();
     }
 
-    public static Date getStartOfLastMonth() {
-
-        Date date = getStartOfCurrentMonth();
-
-        return BusinessEntityUtils.adjustDate(date, Calendar.MONTH, -1);
-
+    public static LocalDateTime getStartOfLastMonth() {
+        return getStartOfCurrentMonth().minusMonths(1);
     }
 
-    public static Date getEndOfLastMonth() {
-
-        Calendar c = Calendar.getInstance();
-
-        Date date = getStartOfLastMonth();
-        c.setTime(date);
-
-        int month = c.get(Calendar.MONTH);
-
-        return BusinessEntityUtils.adjustDate(date, Calendar.DAY_OF_MONTH, getDaysInMonth(month) - 1);
+    public static LocalDateTime getEndOfLastMonth() {
+        return YearMonth.from(LocalDate.now().minusMonths(1)).atEndOfMonth().atStartOfDay();
     }
 
     public static EntityManager getEntityManager(String PU) {
@@ -805,43 +680,68 @@ public class BusinessEntityUtils {
 
     }
 
-    public static Date adjustDate(Date date, int datePart, int amount) {
-        Date adjustedDate = createDate(date);
-
-        Calendar c = Calendar.getInstance();
-        c.setTime(adjustedDate);
-        c.add(datePart, amount);
-
-        return c.getTime();
-    }
-
-    public static int calculatePeriodInWorkingDays(Date startDate, Date endDate) {
-        int workDays = 0;
-
-        Calendar startCal = Calendar.getInstance();
-        startCal.setTime(createDate(startDate));
-
-        Calendar endCal = Calendar.getInstance();
-        endCal.setTime(createDate(endDate));
-
-        if (startCal.after(endCal)) {
-            return 0;
-        } else if (startCal.equals(endCal)) {
-            return 1;
-        } else if (startCal.get(Calendar.DAY_OF_WEEK) == Calendar.SATURDAY
-                || startCal.get(Calendar.DAY_OF_WEEK) == Calendar.SUNDAY) {
-            workDays++;
+    public static LocalDateTime adjustDate(LocalDateTime date, ChronoUnit datePart, int amount) {
+        if (date == null) {
+            return null;
         }
 
-        while (startCal.before(endCal)) {
-            if (startCal.get(Calendar.DAY_OF_WEEK) != Calendar.SATURDAY
-                    && startCal.get(Calendar.DAY_OF_WEEK) != Calendar.SUNDAY) {
+        return createDate(date).plus(amount, datePart);
+    }
+
+    public static LocalDateTime adjustDate(LocalDateTime date, int datePart, int amount) {
+        return adjustDate(date, calendarFieldToChronoUnit(datePart), amount);
+    }
+
+    private static ChronoUnit calendarFieldToChronoUnit(int datePart) {
+        switch (datePart) {
+            case Calendar.YEAR:
+                return ChronoUnit.YEARS;
+            case Calendar.MONTH:
+                return ChronoUnit.MONTHS;
+            case Calendar.DAY_OF_MONTH:
+                return ChronoUnit.DAYS;
+            case Calendar.HOUR:
+            case Calendar.HOUR_OF_DAY:
+                return ChronoUnit.HOURS;
+            case Calendar.MINUTE:
+                return ChronoUnit.MINUTES;
+            case Calendar.SECOND:
+                return ChronoUnit.SECONDS;
+            default:
+                return ChronoUnit.DAYS;
+        }
+    }
+
+    public static int calculatePeriodInWorkingDays(LocalDateTime startDate, LocalDateTime endDate) {
+        int workDays = 0;
+
+        if (startDate == null || endDate == null) {
+            return 0;
+        }
+
+        LocalDate start = startDate.toLocalDate();
+        LocalDate end = endDate.toLocalDate();
+
+        if (start.isAfter(end)) {
+            return 0;
+        } else if (start.equals(end)) {
+            return isWorkingDay(start) ? 1 : 0;
+        }
+
+        LocalDate current = start;
+        while (!current.isAfter(end)) {
+            if (isWorkingDay(current)) {
                 workDays++;
             }
-            startCal.add(Calendar.DAY_OF_MONTH, 1);
+            current = current.plusDays(1);
         }
 
         return workDays;
+    }
+
+    private static boolean isWorkingDay(LocalDate date) {
+        return date.getDayOfWeek() != DayOfWeek.SATURDAY
+                && date.getDayOfWeek() != DayOfWeek.SUNDAY;
     }
 
     public static DatePeriod[] getMonthlyReportDatePeriods(DatePeriod reportingPeriod) {
@@ -852,13 +752,10 @@ public class BusinessEntityUtils {
                         BusinessEntityUtils.adjustDate(reportingPeriod.getEndDate(), Calendar.MONTH, -1),
                         false, false, true);
 
-        Calendar now = Calendar.getInstance();
-        Calendar reportingPeriodEndDateCalendar = Calendar.getInstance();
-        reportingPeriodEndDateCalendar.setTime(reportingPeriod.getEndDate());
-
-        int year = reportingPeriodEndDateCalendar.get(Calendar.YEAR);
-        int monthIndex = now.get(Calendar.MONTH);
-        int day = now.get(Calendar.DAY_OF_MONTH);
+        LocalDateTime now = LocalDateTime.now();
+        int year = reportingPeriod.getEndDate().getYear();
+        int monthIndex = now.getMonthValue() - 1;
+        int day = now.getDayOfMonth();
 
         DatePeriod reportingPeriodYTD = new DatePeriod("Financial year to date",
                 "month",
@@ -894,36 +791,33 @@ public class BusinessEntityUtils {
 
     }
 
-    public static Date getModifiedDate(Date orgDate, int modPeriod, int modAmount) {
-        Calendar calendar;
-
-        calendar = Calendar.getInstance();
-        calendar.setTime(orgDate);
-        calendar.add(modPeriod, modAmount);
-
-        return calendar.getTime();
+    public static LocalDateTime getModifiedDate(LocalDateTime orgDate, int modPeriod, int modAmount) {
+        return adjustDate(orgDate, modPeriod, modAmount);
     }
 
-    public static Boolean areDatesEqual(Date date1, Date date2) {
+    public static Boolean areDatesEqual(LocalDateTime date1, LocalDateTime date2) {
+        if (date1 == null || date2 == null) {
+            return false;
+        }
 
         return removeTimeFromDate(date1).equals(removeTimeFromDate(date2));
     }
 
-    public static Date removeTimeFromDate(Date date) {
-        Calendar cal = Calendar.getInstance();
-
-        cal.setTime(date);
-        cal.set(Calendar.HOUR_OF_DAY, 0);
-        cal.set(Calendar.MINUTE, 0);
-        cal.set(Calendar.SECOND, 0);
-        cal.set(Calendar.MILLISECOND, 0);
-
-        return cal.getTime();
+    public static LocalDateTime removeTimeFromDate(LocalDateTime date) {
+        return createDate(date);
     }
 
     public static Connection getConnection(EntityManager em) {
+        if (em == null) {
+            return null;
+        }
 
-        return em.unwrap(java.sql.Connection.class);
+        try {
+            return em.unwrap(Connection.class);
+        } catch (Exception e) {
+            System.out.println(e);
+            return null;
+        }
     }
 
     public static Connection establishConnection(
@@ -1040,6 +934,7 @@ public class BusinessEntityUtils {
                 EntityManager EM = EMF.createEntityManager();
                 if (EM.isOpen()) {
                     System.out.println("Connected!");
+                    EM.close();
                 }
             } else {
                 return false;
@@ -1072,12 +967,12 @@ public class BusinessEntityUtils {
     }
 
     public static Boolean validateDate(
-            Calendar c,
+            LocalDateTime date,
             int minYear,
             int maxYear) {
 
-        if (c != null) {
-            int year = c.get(Calendar.YEAR);
+        if (date != null) {
+            int year = date.getYear();
             if ((year < minYear) || (year > maxYear)) {
                 return false;
             }
@@ -1127,66 +1022,23 @@ public class BusinessEntityUtils {
         }
     }
 
-    public static String getMonthShortFormat(Date date) {
-        String month;
-        Calendar c = Calendar.getInstance();
-        c.setTime(date);
-
-        switch (c.get(Calendar.MONTH)) {
-            case 0:
-                month = "Jan";
-                break;
-            case 1:
-                month = "Feb";
-                break;
-            case 2:
-                month = "Mar";
-                break;
-            case 3:
-                month = "Apr";
-                break;
-            case 4:
-                month = "May";
-                break;
-            case 5:
-                month = "Jun";
-                break;
-            case 6:
-                month = "Jul";
-                break;
-            case 7:
-                month = "Aug";
-                break;
-            case 8:
-                month = "Sep";
-                break;
-            case 9:
-                month = "Oct";
-                break;
-            case 10:
-                month = "Nov";
-                break;
-            case 11:
-                month = "Dec";
-                break;
-            default:
-                month = "";
-                break;
+    public static String getMonthShortFormat(LocalDateTime date) {
+        if (date == null) {
+            return "";
         }
-        return month;
+
+        return date.getMonth().name().substring(0, 1)
+                + date.getMonth().name().substring(1, 3).toLowerCase();
     }
 
-    public static String getYearShortFormat(Date date, int digits) {
-        String yearString = "";
-        Calendar c = Calendar.getInstance();
-        c.setTime(date);
+    public static String getYearShortFormat(LocalDateTime date, int digits) {
+        if (date == null) {
+            return "";
+        }
 
-        int year = c.get(Calendar.YEAR);
-        yearString = yearString + year;
+        String yearString = "" + date.getYear();
 
-        yearString = yearString.substring(yearString.length() - digits, yearString.length());
-
-        return yearString;
+        return yearString.substring(yearString.length() - digits, yearString.length());
     }
 
     public static String getShortenedString(String string, int maxLength) {
@@ -1249,14 +1101,10 @@ public class BusinessEntityUtils {
     }
 
     public static long getMediumDateStringAsLong(String dateStr) {
-        DateFormat formatter = new SimpleDateFormat("MMM dd, yyyy");
-
         try {
-            Date date = formatter.parse(dateStr);
-
-            return date.getTime();
-        } catch (ParseException ex) {
-            
+            LocalDate date = LocalDate.parse(dateStr, MEDIUM_DATE_FORMATTER);
+            return date.atStartOfDay(DEFAULT_ZONE_ID).toInstant().toEpochMilli();
+        } catch (DateTimeParseException ex) {
             return 0L;
         }
 
@@ -1266,7 +1114,8 @@ public class BusinessEntityUtils {
 
         try {
             if (entity != null) {
-                em.remove(entity);
+                Object managedEntity = em.contains(entity) ? entity : em.merge(entity);
+                em.remove(managedEntity);
             } else {
                 return false;
             }
@@ -1278,6 +1127,7 @@ public class BusinessEntityUtils {
         return true;
     }
 
+    @SuppressWarnings("unchecked")
     public static <T extends BusinessEntity> T attachReference(EntityManager em, T entity) {
 
         if (entity == null) {
@@ -1289,6 +1139,74 @@ public class BusinessEntityUtils {
         }
 
         return em.getReference((Class<T>) entity.getClass(), entity.getId());
+    }
+
+    /*
+     * Legacy java.util.Date overloads retained to make staged migration easier.
+     * Prefer the LocalDateTime overloads above in new BEL/Jakarta code.
+     */
+    public static Boolean isDateWithinPeriod(Date dateToCheck, Date startDate, Date endDate) {
+        return isDateWithinPeriod(toLocalDateTime(dateToCheck), toLocalDateTime(startDate), toLocalDateTime(endDate));
+    }
+
+    public static String getMonthAndYearString(Date date) {
+        return getMonthAndYearString(toLocalDateTime(date));
+    }
+
+    public static String getDateString(Date d, String delim, String format, String sep) {
+        return getDateString(toLocalDateTime(d), delim, format, sep);
+    }
+
+    public static String getDateInMediumDateFormat(Date date) {
+        return getDateInMediumDateFormat(toLocalDateTime(date));
+    }
+
+    public static String getUserDefinedDateFormat(Date date, String format) {
+        return getUserDefinedDateFormat(toLocalDateTime(date), format);
+    }
+
+    public static String getDateInMediumDateAndTimeFormat(Date date) {
+        return getDateInMediumDateAndTimeFormat(toLocalDateTime(date));
+    }
+
+    public static String getDateStringFromDate(Date d, String delim, String format, String sep) {
+        return getDateString(toLocalDateTime(d), delim, format, sep);
+    }
+
+    public static int getIntFromDate(Date date) {
+        return getIntFromDate(toLocalDateTime(date));
+    }
+
+    public static Date adjustDate(Date date, int datePart, int amount) {
+        return toDate(adjustDate(toLocalDateTime(date), datePart, amount));
+    }
+
+    public static int calculatePeriodInWorkingDays(Date startDate, Date endDate) {
+        return calculatePeriodInWorkingDays(toLocalDateTime(startDate), toLocalDateTime(endDate));
+    }
+
+    public static Date getModifiedDate(Date orgDate, int modPeriod, int modAmount) {
+        return toDate(getModifiedDate(toLocalDateTime(orgDate), modPeriod, modAmount));
+    }
+
+    public static Boolean areDatesEqual(Date date1, Date date2) {
+        return areDatesEqual(toLocalDateTime(date1), toLocalDateTime(date2));
+    }
+
+    public static Date removeTimeFromDate(Date date) {
+        return toDate(removeTimeFromDate(toLocalDateTime(date)));
+    }
+
+    public static Boolean validateDate(Calendar c, int minYear, int maxYear) {
+        return c != null && validateDate(toLocalDateTime(c.getTime()), minYear, maxYear);
+    }
+
+    public static String getMonthShortFormat(Date date) {
+        return getMonthShortFormat(toLocalDateTime(date));
+    }
+
+    public static String getYearShortFormat(Date date, int digits) {
+        return getYearShortFormat(toLocalDateTime(date), digits);
     }
 
 }

--- a/src/main/java/jm/com/dpbennett/business/entity/util/DateTimeUtils.java
+++ b/src/main/java/jm/com/dpbennett/business/entity/util/DateTimeUtils.java
@@ -1,0 +1,120 @@
+/*
+Business Entity Library (BEL) - A foundational library.
+Copyright (C) 2026  D P Bennett & Associates Limited
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Email: info@dpbennett.com.jm
+ */
+package jm.com.dpbennett.business.entity.util;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+
+/**
+ * java.time utilities used during and after BEL's migration away from
+ * java.util.Date and Calendar.
+ */
+public final class DateTimeUtils {
+
+    private static final DateTimeFormatter MEDIUM_DATE = DateTimeFormatter.ofPattern("MMM dd, yyyy");
+    private static final DateTimeFormatter MEDIUM_DATE_TIME = DateTimeFormatter.ofPattern("MMM dd, yyyy, h:mm a");
+
+    private DateTimeUtils() {
+    }
+
+    public static LocalDate today() {
+        return LocalDate.now();
+    }
+
+    public static LocalDateTime now() {
+        return LocalDateTime.now();
+    }
+
+    /**
+     * Creates a date using BEL's historical zero-based month index contract.
+     */
+    public static LocalDate createDate(int year, int monthIndex, int day) {
+        return LocalDate.of(year, monthIndex + 1, day);
+    }
+
+    public static boolean isDateWithinPeriod(LocalDate dateToCheck, LocalDate startDate, LocalDate endDate) {
+        return !dateToCheck.isBefore(startDate) && !dateToCheck.isAfter(endDate);
+    }
+
+    public static LocalDate startOfCurrentYear() {
+        return LocalDate.now().withDayOfYear(1);
+    }
+
+    public static LocalDate endOfCurrentYear() {
+        return LocalDate.now().withDayOfYear(LocalDate.now().lengthOfYear());
+    }
+
+    public static LocalDate startOfCurrentMonth() {
+        return LocalDate.now().withDayOfMonth(1);
+    }
+
+    public static LocalDate endOfCurrentMonth() {
+        return YearMonth.from(LocalDate.now()).atEndOfMonth();
+    }
+
+    public static LocalDate adjustDate(LocalDate date, long amount, ChronoUnit unit) {
+        return date.plus(amount, unit);
+    }
+
+    public static int calculatePeriodInWorkingDays(LocalDate startDate, LocalDate endDate) {
+        if (startDate.isAfter(endDate)) {
+            return 0;
+        }
+
+        int workDays = 0;
+        LocalDate current = startDate;
+        while (!current.isAfter(endDate)) {
+            switch (current.getDayOfWeek()) {
+                case SATURDAY, SUNDAY -> {
+                }
+                default -> workDays++;
+            }
+            current = current.plusDays(1);
+        }
+        return workDays;
+    }
+
+    public static String getDateInMediumDateFormat(LocalDate date) {
+        return date == null ? "" : MEDIUM_DATE.format(date);
+    }
+
+    public static String getDateInMediumDateAndTimeFormat(LocalDateTime dateTime) {
+        return dateTime == null ? "" : MEDIUM_DATE_TIME.format(dateTime);
+    }
+
+    public static String getUserDefinedDateFormat(LocalDate date, String format) {
+        return date == null ? "" : DateTimeFormatter.ofPattern(format).format(date);
+    }
+
+    public static int getIntFromDate(LocalDate date) {
+        return date.getYear() * 10000 + date.getMonthValue() * 100 + date.getDayOfMonth();
+    }
+
+    public static LocalDate getDateFromInt(int dateInt) {
+        String value = String.format("%08d", dateInt);
+        return LocalDate.of(
+                Integer.parseInt(value.substring(0, 4)),
+                Integer.parseInt(value.substring(4, 6)),
+                Integer.parseInt(value.substring(6, 8)));
+    }
+}

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -1681,11 +1681,10 @@
         <class>jm.com.dpbennett.business.entity.auth.LdapContext</class>
         <validation-mode>NONE</validation-mode>
         <properties>
-            <property name="javax.persistence.jdbc.url" value="jdbc:mysql://localhost:3306/jmts?zeroDateTimeBehavior=CONVERT_TO_NULL"/>
-            <property name="javax.persistence.jdbc.user" value="root"/>
+            <property name="javax.persistence.jdbc.url" value="jdbc:mysql://localhost:3306/jmts-2026-02-07?zeroDateTimeBehavior=CONVERT_TO_NULL"/>
+            <property name="javax.persistence.jdbc.user" value="test"/>
             <property name="javax.persistence.jdbc.driver" value="com.mysql.cj.jdbc.Driver"/>
-            <property name="javax.persistence.jdbc.password" value=""/>
-            <property name="javax.persistence.schema-generation.database.action" value="create"/>
+            <property name="javax.persistence.jdbc.password" value="1234567890"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/src/test/java/jm/com/dpbennett/business/entity/test/EntityTest.java
+++ b/src/test/java/jm/com/dpbennett/business/entity/test/EntityTest.java
@@ -19,10 +19,10 @@ Email: info@dpbennett.com.jm
  */
 package jm.com.dpbennett.business.entity.test;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.Persistence;
 import java.util.List;
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.Persistence;
 import jm.com.dpbennett.business.entity.cm.Client;
 import org.junit.Test;
 

--- a/src/test/java/jm/com/dpbennett/business/entity/test/MailAPITest.java
+++ b/src/test/java/jm/com/dpbennett/business/entity/test/MailAPITest.java
@@ -19,9 +19,9 @@ Email: info@dpbennett.com.jm
  */
 package jm.com.dpbennett.business.entity.test;
 
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.Persistence;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.Persistence;
 import jm.com.dpbennett.business.entity.util.MailUtils;
 import org.junit.Test;
 

--- a/src/test/java/jm/com/dpbennett/business/entity/utils/CreateInventory.java
+++ b/src/test/java/jm/com/dpbennett/business/entity/utils/CreateInventory.java
@@ -19,9 +19,6 @@ Email: info@dpbennett.com.jm
  */
 package jm.com.dpbennett.business.entity.utils;
 
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.Persistence;
 import jm.com.dpbennett.business.entity.im.Inventory;
 import jm.com.dpbennett.business.entity.fm.MarketProduct;
 import jm.com.dpbennett.business.entity.hrm.Employee;

--- a/src/test/java/jm/com/dpbennett/business/entity/utils/CreateInventoryDisbursement.java
+++ b/src/test/java/jm/com/dpbennett/business/entity/utils/CreateInventoryDisbursement.java
@@ -20,9 +20,6 @@ Email: info@dpbennett.com.jm
 package jm.com.dpbennett.business.entity.utils;
 
 import java.util.Date;
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.Persistence;
 import jm.com.dpbennett.business.entity.im.Inventory;
 import jm.com.dpbennett.business.entity.im.InventoryDisbursement;
 import jm.com.dpbennett.business.entity.hrm.Employee;

--- a/src/test/java/jm/com/dpbennett/business/entity/utils/CreateInventoryRequisition.java
+++ b/src/test/java/jm/com/dpbennett/business/entity/utils/CreateInventoryRequisition.java
@@ -20,9 +20,6 @@ Email: info@dpbennett.com.jm
 package jm.com.dpbennett.business.entity.utils;
 
 import java.util.Date;
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.Persistence;
 import jm.com.dpbennett.business.entity.im.Inventory;
 import jm.com.dpbennett.business.entity.im.InventoryDisbursement;
 import jm.com.dpbennett.business.entity.im.InventoryRequisition;


### PR DESCRIPTION
## Summary

Restarts the BEL v7 migration from the `v7.0.0` branch with a clean Java 17 / Jakarta EE 11 foundation.

## Initial changes

- Compile BEL with Java 17 using `maven.compiler.release`.
- Replace the Java EE 8 aggregate API with `jakarta.jakartaee-api:11.0.0`.
- Move mail dependencies from `javax.mail` to Jakarta Mail / Angus Mail.
- Update the `BusinessEntity` contract from `javax.persistence.EntityManager` to `jakarta.persistence.EntityManager`.
- Replace audit `Date` values (`dateEntered`, `dateEdited`) in the core contract with `LocalDateTime`.
- Add `DateTimeUtils` as the java.time migration foundation for `LocalDate` and `LocalDateTime` operations.

## Migration policy

- Use `LocalDate` for calendar-only business dates.
- Use `LocalDateTime` for audit/event timestamps where both date and local time are required.
- Remove `@Temporal` as fields are migrated to java.time types.
- Replace `javax.*` Jakarta EE imports with `jakarta.*`; Java SE `javax.*` packages such as `javax.naming` remain unchanged.

## Remaining work in this PR

The repository contains many entities still using `javax.persistence` and `java.util.Date`. They will be migrated systematically on this branch, with compile errors used to identify dependent interfaces/entities and avoid unsafe blind replacements.

The PR is opened as a draft because the migration is not yet build-complete.